### PR TITLE
Initialising affectedSettings to ["titleBar"]

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ import {
   promptForHexColor,
   changeColorSetting,
   generateRandomHexColor,
-  builtInColors
+  builtInColors,
+  initialiseAffectedSettings
 } from './utils';
 
 // this method is called when your extension is activated
@@ -67,6 +68,8 @@ export function activate(context: vscode.ExtensionContext) {
       changeColorSetting(backgroundHex, foregroundHex);
     }
   );
+
+  initialiseAffectedSettings();
 
   // context.subscriptions.push(disposable);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,9 +142,7 @@ export function generateRandomHexColor() {
 
 export async function isSelected(setting: string) {
   // grab the settings array from their settings.json file
-  const peacockAffectedSettings: string[] = await vscode.workspace
-    .getConfiguration('peacock')
-    .get('affectedSettings', []);
+  const peacockAffectedSettings: string[] = await getAffectedSettings();
 
   // check if they requested a setting
   const itExists: boolean = !!(
@@ -152,4 +150,41 @@ export async function isSelected(setting: string) {
   );
 
   return itExists;
+}
+
+type AffectedSetting = 'titleBar' | 'statusBar' | 'activityBar';
+
+async function getAffectedSettings(): Promise<AffectedSetting[]> {
+  return vscode.workspace
+    .getConfiguration('peacock')
+    .get<AffectedSetting[]>('affectedSettings', []);
+}
+
+async function setAffectedSettings(settings: AffectedSetting[]) {
+  vscode.workspace
+    .getConfiguration('peacock')
+    .update('affectedSettings', settings, false);
+}
+
+export async function initialiseAffectedSettings() {
+  const peacockAffectedSettings = await getAffectedSettings();  
+  if(peacockAffectedSettings.length === 0) {
+    toggleAffectedSetting('titleBar', true);
+  }
+}
+
+export async function toggleAffectedSetting(
+  setting: 'titleBar' | 'statusBar' | 'activityBar',
+  value: boolean
+) {
+  const settings = await getAffectedSettings();
+
+  if (settings.includes(setting) && !value){
+    settings.splice(settings.indexOf(setting),1);
+  }  
+  if (settings.includes(setting) === false && value){
+    settings.push(setting);
+  }
+
+  await setAffectedSettings(settings);
 }


### PR DESCRIPTION
Fixes: https://github.com/johnpapa/vscode-peacock/issues/23

Initialising `peacock.affectedSettings` to `["titleBar"]` when the extension is activated.

```
 "peacock.affectedSettings": [
    "titleBar"
  ]
```

**Note:** this would only initialise the first time a peacock command is used. If the user later deletes settings.json or removes the above block from it. The extension won't regenerate it.


