### PR TITLE
Colorize status bar item hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the code will be documented in this file.
 
+## 1.0.0
+
+Other Changes
+
+- Added colorization of items in the status bar on hover to better fit with the color that Peacock applies.
+
 ## 0.7.0
 
 Features

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -14,6 +14,14 @@ export function getInactiveBackgroundColorHex(backgroundColor = '') {
   return formatHex(tinycolor.mix(background, tinycolor('black'), 50));
 }
 
+export function getBackgroundHoverColorHex(backgroundColor = '') {
+  const background = tinycolor(backgroundColor);
+  const hoverColor = background.isLight()
+    ? background.darken()
+    : background.lighten();
+  return formatHex(hoverColor);
+}
+
 export function getForegroundColorHex(backgroundColor = '') {
   const background = tinycolor(backgroundColor);
   const foreground = background.isLight()

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -69,6 +69,6 @@ export function isValidColorInput(input: string) {
   return tinycolor(input).isValid();
 }
 
-function formatHex(color: tinycolorInstance) {
+function formatHex(color: tinycolor.Instance) {
   return color.getAlpha() < 1 ? color.toHex8String() : color.toHexString();
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,7 +17,8 @@ import {
   getForegroundColorHex,
   getInactiveBackgroundColorHex,
   getInactiveForegroundColorHex,
-  getAdjustedColorHex
+  getAdjustedColorHex,
+  getBackgroundHoverColorHex
 } from './color-library';
 import * as vscode from 'vscode';
 
@@ -183,6 +184,7 @@ export function getElementStyle(
 
   return {
     backgroundHex: styleHex,
+    backgroundHoverHex: getBackgroundHoverColorHex(styleHex),
     foregroundHex: getForegroundColorHex(styleHex),
     inactiveBackgroundHex: getInactiveBackgroundColorHex(styleHex),
     inactiveForegroundHex: getInactiveForegroundColorHex(styleHex)
@@ -241,6 +243,8 @@ function collectStatusBarSettings(
     const statusBarStyle = getElementStyle(backgroundHex, 'statusBar');
     statusBarSettings[ColorSettings.statusBar_background] =
       statusBarStyle.backgroundHex;
+    statusBarSettings[ColorSettings.statusBarItem_hoverBackground] =
+      statusBarStyle.backgroundHoverHex;
 
     if (!keepForegroundColor) {
       statusBarSettings[ColorSettings.statusBar_foreground] =

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -31,7 +31,8 @@ export enum ColorSettings {
   activityBar_foreground = 'activityBar.foreground',
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',
   statusBar_background = 'statusBar.background',
-  statusBar_foreground = 'statusBar.foreground'
+  statusBar_foreground = 'statusBar.foreground',
+  statusBarItem_hoverBackground = 'statusBarItem.hoverBackground'
 }
 
 export type ColorAdjustment = 'lighten' | 'darken' | 'none';

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -23,6 +23,7 @@ export interface IConfiguration {
 
 export interface IElementStyle {
   backgroundHex: string;
+  backgroundHoverHex: string;
   foregroundHex: string;
   inactiveBackgroundHex: string;
   inactiveForegroundHex: string;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -494,6 +494,37 @@ suite('Extension Basic Tests', () => {
         await updateAffectedElements(allAffectedElements);
       });
     });
+
+    suite('Status Bar', () => {
+      test('does not set item hover color when status bar is not affected', async () => {
+        await updateAffectedElements({
+          activityBar: true,
+          statusBar: false,
+          titleBar: true
+        });
+
+        const value = await getColorSettingAfterEnterColor(BuiltInColors.Angular, ColorSettings.statusBarItem_hoverBackground);
+        assert.ok(!value);
+
+        await updateAffectedElements(allAffectedElements);
+      });
+
+      test('sets item hover color to darker on a light background', async () => {
+        const config = await getPeacockWorkspaceConfigAfterEnterColor('hsl(0 0.5 0.75)');
+        const backgroundHex = config[ColorSettings.statusBar_background];
+        const hoverBackgroundHex = config[ColorSettings.statusBarItem_hoverBackground];
+
+        assert.ok(getColorBrightness(backgroundHex) > getColorBrightness(hoverBackgroundHex));
+      });
+
+      test('sets item hover color to lighter on a dark background', async () => {
+        const config = await getPeacockWorkspaceConfigAfterEnterColor('hsl(0 0.5 0.25)');
+        const backgroundHex = config[ColorSettings.statusBar_background];
+        const hoverBackgroundHex = config[ColorSettings.statusBarItem_hoverBackground];
+
+        assert.ok(getColorBrightness(backgroundHex) < getColorBrightness(hoverBackgroundHex));
+      });
+    });
   });
 
   suite('Element adjustments', () => {
@@ -711,6 +742,36 @@ async function testsSetsColorCustomizationsForAffectedElements() {
     ColorSettings.statusBar_foreground,
     keepForegroundColor
   );
+}
+
+async function getPeacockWorkspaceConfigAfterEnterColor(colorInput: string) {
+
+  // Stub the async input box to return a response
+  const stub = await sinon
+    .stub(vscode.window, 'showInputBox')
+    .returns(Promise.resolve(colorInput));
+
+  // fire the command
+  await vscode.commands.executeCommand(Commands.enterColor);
+  const config = getPeacockWorkspaceConfig();
+  stub.restore();
+
+  return config;
+}
+
+async function getColorSettingAfterEnterColor(colorInput: string, setting: ColorSettings) {
+
+  // Stub the async input box to return a response
+  const stub = await sinon
+    .stub(vscode.window, 'showInputBox')
+    .returns(Promise.resolve(colorInput));
+
+  // fire the command
+  await vscode.commands.executeCommand(Commands.enterColor);
+  const config = getPeacockWorkspaceConfig();
+  stub.restore();
+
+  return config[setting];
 }
 
 function getPeacockWorkspaceConfig() {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -611,6 +611,8 @@ suite('Extension Basic Tests', () => {
         let config = getPeacockWorkspaceConfig();
         assert.ok(!config[ColorSettings.activityBar_badgeBackground]);
         assert.ok(!config[ColorSettings.activityBar_badgeBackground]);
+
+        await updateAffectedElements(allAffectedElements);
       });
 
       test('activity bar badge is readable over white activity bar', async () => {


### PR DESCRIPTION
## Purpose

- Colorize the Status Bar Item hover background as part of the process that Peacock manages when that element is being affected to improve visual coherence of the color that Peacock applies when the user interacts with the element.

## What

- Closes #60 
- The existing behavior of Peacock in 0.7.0 and below would not colorize the Status Bar item hover color, so when the user interacted with the status bar the hover color would revert to the theme hover color which could be a very different color from the one Peacock applied.
- When the Status Bar is affected and colorized, the item hover background color will be set to a slightly different shade of the background color to provide the visual cue of the hover state, but not make the difference a potentially jarring one.
  - If the background is a light color, the hover will be slightly darker.
  - If the background is a dark color, the hover will be slightly lighter.

## How to Test

- Tests added for status bar hover color

## Checklist of changes included

- [x] CHANGELOG updated
- [ ] README updated
- [x] Tests updated/added
- [x] Prettier formatting
- [x] console.log removed
- [x] Dead code removed
- [x] Unnecessary comments removed
- [ ] Images updated (if applicable)