### PR TITLE
Use alpha for titlebar and activitybar inactive colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Other Changes
 
 - Added colorization of items in the status bar on hover to better fit with the color that Peacock applies.
 - Added colorization of the Activity Bar badge based on the background color applied by Peacock to improve readability
-- Modified inactive element coloring to better match default behavior of VS Code and most themes.
+- Refactored inactive element coloring to better match default behavior of VS Code and most themes.
+- Added azure devops CI process to test on macos, linux and windows with Node 8 and 10
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Other Changes
 
 - Added colorization of items in the status bar on hover to better fit with the color that Peacock applies.
 - Added colorization of the Activity Bar badge based on the background color applied by Peacock to improve readability
+- Modified inactive element coloring to better match default behavior of VS Code and most themes.
 
 ## 0.7.0
 

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -1,5 +1,10 @@
 import * as tinycolor from 'tinycolor2';
-import { ColorAdjustment, ForegroundColors, ReadabilityRatios } from './models';
+import { 
+  ColorAdjustment, 
+  ForegroundColors, 
+  ReadabilityRatios, 
+  inactiveElementAlpha 
+} from './models';
 
 export function getColorHex(color = '') {
   return formatHex(tinycolor(color));
@@ -11,7 +16,8 @@ export function getBackgroundColorHex(color = '') {
 
 export function getInactiveBackgroundColorHex(backgroundColor = '') {
   const background = tinycolor(backgroundColor);
-  return formatHex(tinycolor.mix(background, tinycolor('black'), 50));
+  background.setAlpha(inactiveElementAlpha);
+  return formatHex(background);
 }
 
 export function getBackgroundHoverColorHex(backgroundColor = '') {
@@ -32,8 +38,8 @@ export function getForegroundColorHex(backgroundColor = '') {
 
 export function getInactiveForegroundColorHex(backgroundColor = '') {
   const foreground = tinycolor(getForegroundColorHex(backgroundColor));
-  const background = tinycolor(backgroundColor);
-  return formatHex(tinycolor.mix(foreground, background, 25));
+  foreground.setAlpha(inactiveElementAlpha);
+  return formatHex(foreground);
 }
 
 export function getReadableAccentColorHex(

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,2 +1,6 @@
 export const extSuffix = 'peacock';
 export const preferredColorSeparator = '->';
+
+// Matches the default inactive alpha in VS Code of 0x99
+// represented in 0-1 range for tinycolor.setAlpha()
+export const inactiveElementAlpha = 0x99 / 0xFF;


### PR DESCRIPTION
## Purpose

- Make the inactive background and foreground colors look better and match the default behavior of VS Code.

## What

- I never quite felt right about the inactive color treatment done in #48 where I mixed the titlebar background with black and I mixed the activity bar foreground with its background color. The title bar to me just feels off and wouldn't work well with a light theme. The activity bar icons generally worked well, but not at all color values and sometimes the visual contrast just wasn't enough to notice the difference. Below is what it looks like with Peacock 0.7.0 and React Blue. Notice that the titlebar is pretty dark and the foreground text of it is very difficult to read. It is difficult to distinguish the inactive (Explorer) icon from the active (Search) icon. Finally, it looks bad on a light theme because the mixing with black in the titlebar makes it far too dark:

<img width="351" alt="Screen Shot 2019-03-08 at 10 12 22 PM" src="https://user-images.githubusercontent.com/1085791/54066064-59bc1b80-41ef-11e9-945f-0d0784e02042.png"> <img width="304" alt="Screen Shot 2019-03-08 at 10 17 12 PM" src="https://user-images.githubusercontent.com/1085791/54066088-fc749a00-41ef-11e9-929f-d66c2f499280.png">

- Researching the default style a bit, I noticed that the theme is using Hex8 colors with an alpha of 0x99 to simply reduce the opacity of the active color. It appears to be doing this for all inactive colors. As such, this code simplifies and standardizes the inactive treatment to match the default VS Code look and feel which I think looks much better. With these changes the issues I noted above are corrected:

<img width="318" alt="Screen Shot 2019-03-08 at 10 10 39 PM" src="https://user-images.githubusercontent.com/1085791/54066136-cbe13000-41f0-11e9-88b9-96cfdf316d1d.png"> <img width="312" alt="Screen Shot 2019-03-08 at 10 21 21 PM" src="https://user-images.githubusercontent.com/1085791/54066138-ce438a00-41f0-11e9-8ff5-b518c7ada3b0.png">


## How to Test

- I chose not to add a test for this since it is a specific color implementation. If you would like a test I would be happy to write one.
- Manual testing to see the activity bar icons in different colors. Lose focus on the window to see inactive title bar treatment.

## Checklist of changes included

- [x] CHANGELOG updated
- [ ] README updated
- [ ] Tests updated/added
- [x] Prettier formatting
- [x] console.log removed
- [x] Dead code removed
- [x] Unnecessary comments removed
- [ ] Images updated (if applicable)