### PR TITLE
Add ability to surprise me on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the code will be documented in this file.
 
 ## 1.2.2
 
+Features
+
+- _Surprise Me On Startup_: When enabled, Peacock will automatically apply a random color on startup when opening any workspace that does not already have color customizations defined.
+
 Other Changes
 
 - Added logging to an output channel for diagnostics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to the code will be documented in this file.
 
-## 1.2.2
+## 1.3.0
 
 Features
 
-- _Surprise Me On Startup_: When enabled, Peacock will automatically apply a random color on startup when opening any workspace that does not already have color customizations defined.
+- _Surprise Me On Startup_: When enabled, Peacock will automatically apply a random color on startup when opening any workspace that does not already have color customizations defined. It will also show an information dialog in case the user forgot this setting is enabled.
 
 Other Changes
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Commands can be found in the command palette. Look for commands beginning with `
 | peacock.elementAdjustments  | fine tune coloring of affected elements                                                               |
 | peacock.favoriteColors      | array of objects for color names and hex values                                                       |
 | peacock.keepForegroundColor | Specifies whether Peacock should change affect colors                                                 |
+| peacock.surpriseMeOnStartup | Specifies whether Peacock apply a random color on startup                                           |
 
 ### Favorite Colors
 
@@ -108,6 +109,12 @@ When using peacock with the Angular Red color, this results in the Activity Bar 
 Recommended to remain false (the default value).
 
 When set to true Peacock will not colorize the foreground of any of the affected elements and will only alter the background. Some users may desire this if their theme's foreground is their preference over Peacock. In this case, when set to true, the foreground will not be affected.
+
+## Surprise Me On Startup
+
+Recommended to remain false (the default value).
+
+When set to true Peacock will automatically apply a random color when opening a workspace that does not define color customizations. This can be useful if you frequently open many instances of VS Code and you are interested in quickly and easily telling them apart, but are not overly committed to the specific color applied.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
             "type": "object"
           },
           "description": "Your favorite colors"
+        },
+        "peacock.surpriseMeOnStartup": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies that Peacock should surprise you at the start of every editing session"
         }
       }
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import {
   deletePeacocksColorCustomizations
 } from './color-library';
 
-import { BuiltInColors, State } from './models';
+import { BuiltInColors, State, StandardSettings } from './models';
 import {
   updateWorkspaceConfiguration,
   getCurrentColorBeforeAdjustments,
@@ -17,6 +17,7 @@ import {
   promptForFavoriteColorName
 } from './inputs';
 import { isObjectEmpty } from './helpers';
+import { window } from 'vscode';
 
 export async function resetColorsHandler() {
   const colorCustomizations = deletePeacocksColorCustomizations();
@@ -48,7 +49,12 @@ export async function enterColorHandler() {
 }
 
 export async function changeColorToRandomHandler() {
-  return await changeColor(getRandomColorHex());
+  const color = await changeColor(getRandomColorHex());
+  const message = `Peacock changed the base accent colors to ${color}, because the setting is enabled for ${
+    StandardSettings.SurpriseMeOnStartup
+  }`;
+  window.showInformationMessage(message);
+  return color;
 }
 
 export async function changeColorToVueGreenHandler() {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,7 +14,8 @@ import {
   ISettingsIndexer,
   ElementNames,
   ColorAdjustmentOptions,
-  IElementColors
+  IElementColors,
+  state
 } from './models';
 import {
   getAdjustedColorHex,
@@ -22,7 +23,8 @@ import {
   getBackgroundHoverColorHex,
   getForegroundColorHex,
   getInactiveBackgroundColorHex,
-  getInactiveForegroundColorHex
+  getInactiveForegroundColorHex,
+  changeColor
 } from './color-library';
 import * as vscode from 'vscode';
 import { Logger } from './logging';
@@ -142,6 +144,13 @@ export function getFavoriteColors() {
   };
 }
 
+export function getSurpriseMeOnStartup() {
+  return readConfiguration<boolean>(
+    StandardSettings.SurpriseMeOnStartup,
+    false
+  );
+}
+
 export function getAffectedElements() {
   return <IPeacockAffectedElementSettings>{
     activityBar:
@@ -179,6 +188,10 @@ export async function updateKeepBadgeColor(value: boolean) {
     StandardSettings.KeepBadgeColor,
     value
   );
+}
+
+export async function updateSurpriseMeOnStartup(value: boolean) {
+  return await updateConfiguration(StandardSettings.SurpriseMeOnStartup, value);
 }
 
 export async function addNewFavoriteColor(name: string, value: string) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,8 +14,7 @@ import {
   ISettingsIndexer,
   ElementNames,
   ColorAdjustmentOptions,
-  IElementColors,
-  state
+  IElementColors
 } from './models';
 import {
   getAdjustedColorHex,
@@ -191,7 +190,7 @@ export async function updateKeepBadgeColor(value: boolean) {
 }
 
 export async function updateSurpriseMeOnStartup(value: boolean) {
-  return await updateConfiguration(StandardSettings.SurpriseMeOnStartup, value);
+  return await updateGlobalConfiguration(StandardSettings.SurpriseMeOnStartup, value);
 }
 
 export async function addNewFavoriteColor(name: string, value: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,12 +26,8 @@ export function activate(context: vscode.ExtensionContext) {
   console.log('Extension "vscode-peacock" is now active!');
 
   registerCommands();
-
-  State.recentColor = getCurrentColorBeforeAdjustments();
-
   addSubscriptions(context);
-
-  // context.subscriptions.push(disposable);
+  applyInitialConfiguration();
 }
 
 function addSubscriptions(context: vscode.ExtensionContext) {
@@ -82,23 +78,13 @@ function registerCommands() {
     Commands.changeColorToFavorite,
     changeColorToFavoriteHandler
   );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration(async e => {
-      if (checkIfPeacockSettingsChanged(e) && state.recentColor) {
-        await changeColor(state.recentColor);
-      }
-    })
-  );
-
-  applyInitialConfiguration();
 }
 
 export async function applyInitialConfiguration()
 {
-  state.recentColor = getCurrentColorBeforeAdjustments();
+  State.recentColor = getCurrentColorBeforeAdjustments();
 
-  if (!state.recentColor && getSurpriseMeOnStartup()) {
+  if (!State.recentColor && getSurpriseMeOnStartup()) {
     await changeColorToRandomHandler();
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,8 @@ import {
 } from './commands';
 import {
   checkIfPeacockSettingsChanged,
-  getCurrentColorBeforeAdjustments
+  getCurrentColorBeforeAdjustments,
+  getSurpriseMeOnStartup
 } from './configuration';
 import { changeColor } from './color-library';
 import { Logger } from './logging';
@@ -81,6 +82,25 @@ function registerCommands() {
     Commands.changeColorToFavorite,
     changeColorToFavoriteHandler
   );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async e => {
+      if (checkIfPeacockSettingsChanged(e) && state.recentColor) {
+        await changeColor(state.recentColor);
+      }
+    })
+  );
+
+  applyInitialConfiguration();
+}
+
+export async function applyInitialConfiguration()
+{
+  state.recentColor = getCurrentColorBeforeAdjustments();
+
+  if (!state.recentColor && getSurpriseMeOnStartup()) {
+    await changeColorToRandomHandler();
+  }
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,12 +22,12 @@ import { Logger } from './logging';
 
 const { commands, workspace } = vscode;
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   console.log('Extension "vscode-peacock" is now active!');
 
   registerCommands();
   addSubscriptions(context);
-  applyInitialConfiguration();
+  await applyInitialConfiguration();
 }
 
 function addSubscriptions(context: vscode.ExtensionContext) {

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -2,7 +2,8 @@ export enum StandardSettings {
   FavoriteColors = 'favoriteColors',
   ElementAdjustments = 'elementAdjustments',
   KeepBadgeColor = 'keepBadgeColor',
-  KeepForegroundColor = 'keepForegroundColor'
+  KeepForegroundColor = 'keepForegroundColor',
+  SurpriseMeOnStartup = 'surpriseMeOnStartup'
 }
 
 export enum AffectedSettings {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -46,6 +46,7 @@ export interface IPeacockSettings {
   elementAdjustments: IPeacockElementAdjustments;
   favoriteColors: IFavoriteColors[];
   keepForegroundColor: boolean;
+  surpriseMeOnStartup: boolean;
 }
 
 export interface IElementColors {

--- a/src/test/lib/setup-teardown-test-suite.ts
+++ b/src/test/lib/setup-teardown-test-suite.ts
@@ -10,7 +10,8 @@ import {
   updateFavoriteColors,
   updateElementAdjustments,
   updateKeepForegroundColor,
-  getKeepForegroundColor
+  getKeepForegroundColor,
+  updateSurpriseMeOnStartup
 } from '../../configuration';
 
 import { getExtension, updateAffectedElements } from './helpers';
@@ -48,6 +49,7 @@ export async function setupTestSuite(
     { name: 'Azure Blue', value: '#007fff' }
   ]);
   await updateKeepForegroundColor(false);
+  await updateSurpriseMeOnStartup(false);
   await updateElementAdjustments(noopElementAdjustments);
   return extension;
 }
@@ -59,4 +61,5 @@ export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await updateElementAdjustments(originalValues.elementAdjustments);
   await updateFavoriteColors(originalValues.favoriteColors);
   await updateKeepForegroundColor(originalValues.keepForegroundColor);
+  await updateSurpriseMeOnStartup(originalValues.surpriseMeOnStartup);
 }

--- a/src/test/surprise-me-on-startup.test.ts
+++ b/src/test/surprise-me-on-startup.test.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import {
+  Commands,
+  IPeacockSettings,
+  IPeacockAffectedElementSettings,
+  IElementColors,
+  ElementNames,
+} from '../models';
+import { allSetupAndTeardown } from './lib/setup-teardown-test-suite';
+import { executeCommand } from './lib/constants';
+import {
+  getOriginalColorsForAllElements,
+  updateSurpriseMeOnStartup
+} from '../configuration';
+import { applyInitialConfiguration } from '../extension';
+import { updateAffectedElements } from './lib/helpers';
+
+suite('Surprise me on startup', () => {
+  let originalValues = <IPeacockSettings>{};
+  allSetupAndTeardown(originalValues);
+
+  setup(async () => {
+    await executeCommand(Commands.resetColors);
+    await updateAffectedElements(<IPeacockAffectedElementSettings>{
+      statusBar: true,
+      activityBar: true,
+      titleBar: true
+    });
+  });
+
+  test('when not set has no effect if no customizations exist', async () => {
+    await testColorsBeforeAndAfterInitialConfiguration(assert.equal);
+  });
+
+  suite('when set', () => {
+    setup(async () => {
+      await updateSurpriseMeOnStartup(true);
+    });
+
+    test('applies a random color if no color customizations exist', async () => {
+      await testColorsBeforeAndAfterInitialConfiguration(assert.notEqual);
+    });
+
+    test('has no effect when color customizations exist', async () => {
+      await vscode.commands.executeCommand(Commands.changeColorToAngularRed);
+      await testColorsBeforeAndAfterInitialConfiguration(assert.equal);
+    });
+
+    teardown(async () => {
+      await updateSurpriseMeOnStartup(false);
+    });
+  });
+
+  async function testColorsBeforeAndAfterInitialConfiguration(assertEquality: EqualityAssertion) {
+    const colors1: IElementColors = getOriginalColorsForAllElements();
+    await applyInitialConfiguration();
+    const colors2: IElementColors = getOriginalColorsForAllElements();
+    assertEquality(colors1[ElementNames.activityBar], colors2[ElementNames.activityBar]);
+    assertEquality(colors1[ElementNames.statusBar], colors2[ElementNames.statusBar]);
+    assertEquality(colors1[ElementNames.titleBar], colors2[ElementNames.titleBar]);
+  }
+
+  interface EqualityAssertion {
+    (actual: any, expected: any, message?: string | Error | undefined): void;
+  }
+});


### PR DESCRIPTION
## Purpose

- Adds a _Surprise Me On Startup_ setting that when enabled with apply a random color when opening any workspace that does not already have color customizations defined.

## What

- This was asked for in #33 and discussed there. When set, it will apply a random color to a workspace if there are not already colors defined in that workspace. Once the random color is applied, it will remain with the workspace until the colors are reset.

## How to Test

- Tests added.
- Make sure the setting is enabled and open a new or existing workspace that does not have color customizations applied and observe that a random color is applied.

## What to Check

Verify that the following are valid

- I am not certain on the name of the setting with "on startup". It actually only takes affect when opening a workspace/folder because doing so causes a window reload that then invokes the startup logic. Starting up to an empty VS Code instance has no effect and I don't believe Peacock currently works in that scenario either, so it seems like it could be misleading.

## Checklist of changes included

- [x] CHANGELOG updated
- [x] README updated
- [x] Tests updated/added
- [ ] Prettier formatting
- [x] console.log removed
- [x] Dead code removed
- [x] Unnecessary comments removed
- [ ] Images updated (if applicable)
