### PR TITLE
Add C# Purple as favorite

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,13 +9,9 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "workbench.colorCustomizations": {
-    "activityBar.background": "#1f6fd0",
-    "activityBar.foreground": "#e7e7e7",
-    "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#ee90bb",
-    "activityBarBadge.foreground": "#15202b",
-    "statusBar.background": "#1857a4",
-    "statusBarItem.hoverBackground": "#1f6fd0",
-    "statusBar.foreground": "#e7e7e7"
+    "titleBar.activeBackground": "#1857a4",
+    "titleBar.inactiveBackground": "#1857a499",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveForeground": "#e7e7e799"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,9 +9,13 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#1857a4",
-    "titleBar.inactiveBackground": "#1857a499",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "activityBar.background": "#1f6fd0",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#ee90bb",
+    "activityBarBadge.foreground": "#15202b",
+    "statusBar.background": "#1857a4",
+    "statusBarItem.hoverBackground": "#1f6fd0",
+    "statusBar.foreground": "#e7e7e7"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to the code will be documented in this file.
 Features
 
 - Added _C# Purple_ `#68217A` to favorites for .NET Core
-- Refactored to remove dead code and remove helper functions
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the code will be documented in this file.
 
+## 2.1.1
+
+Features
+
+- Added _C# Purple_ `#68217A` to favorites for .NET Core
+
 ## 2.1.0
 
 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the code will be documented in this file.
 Features
 
 - Added _C# Purple_ `#68217A` to favorites for .NET Core
+- Refactored to remove dead code and remove helper functions
 
 ## 2.1.0
 

--- a/src/models/favorites.ts
+++ b/src/models/favorites.ts
@@ -8,5 +8,7 @@ export const starterSetOfFavorites = [
   { name: 'Node Green', value: '#215732' },
   { name: 'React Blue', value: '#00b3e6' },
   { name: 'Something Different', value: '#832561' },
-  { name: 'Vue Green', value: '#42b883' }
+  { name: 'Vue Green', value: '#42b883' },
+  { name: 'C# Purple', value: '#68217A'}
+
 ];

--- a/src/models/favorites.ts
+++ b/src/models/favorites.ts
@@ -9,5 +9,5 @@ export const starterSetOfFavorites = [
   { name: 'React Blue', value: '#00b3e6' },
   { name: 'Something Different', value: '#832561' },
   { name: 'Vue Green', value: '#42b883' },
-  { name: 'C# Purple', value: '#68217A'}
+  { name: 'C# Purple', value: '#68217A' }
 ];

--- a/src/models/favorites.ts
+++ b/src/models/favorites.ts
@@ -2,12 +2,12 @@ export const starterSetOfFavorites = [
   { name: 'Angular Red', value: '#b52e31' },
   { name: 'Auth0 Orange', value: '#eb5424' },
   { name: 'Azure Blue', value: '#007fff' },
+  { name: 'C# Purple', value: '#68217A' },
   { name: 'Gatsby Purple', value: '#639' },
   { name: 'JavaScript Yellow', value: '#f9e64f' },
   { name: 'Mandalorian Blue', value: '#1857a4' },
   { name: 'Node Green', value: '#215732' },
   { name: 'React Blue', value: '#00b3e6' },
   { name: 'Something Different', value: '#832561' },
-  { name: 'Vue Green', value: '#42b883' },
-  { name: 'C# Purple', value: '#68217A' }
+  { name: 'Vue Green', value: '#42b883' }
 ];

--- a/src/models/favorites.ts
+++ b/src/models/favorites.ts
@@ -10,5 +10,4 @@ export const starterSetOfFavorites = [
   { name: 'Something Different', value: '#832561' },
   { name: 'Vue Green', value: '#42b883' },
   { name: 'C# Purple', value: '#68217A'}
-
 ];


### PR DESCRIPTION
# Title
Added .NET purple logo hex as C# color favorite

## Purpose

- Add a color favorite for .NET Core Developers

## How to Test

- CMD + Shift + P (MacOS) or Ctrl + Shift + P (Win), Type Peacock: Change to favorite color > C# Purple `#68217A`

## What to Check

Title Bar and or Side bar is purple as configured for Peacock
