### PR TITLE
Added Java Blue-Gray to favourites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the code will be documented in this file.
 
+## 2.1.2
+
+Features
+
+- Added _Java Blue-Gray_ `#557c9b` to favourites for Java
+
 ## 2.1.1
 
 Features

--- a/src/models/favorites.ts
+++ b/src/models/favorites.ts
@@ -4,6 +4,7 @@ export const starterSetOfFavorites = [
   { name: 'Azure Blue', value: '#007fff' },
   { name: 'C# Purple', value: '#68217A' },
   { name: 'Gatsby Purple', value: '#639' },
+  { name: 'Java Blue-Gray', value: '#557c9b' },
   { name: 'JavaScript Yellow', value: '#f9e64f' },
   { name: 'Mandalorian Blue', value: '#1857a4' },
   { name: 'Node Green', value: '#215732' },


### PR DESCRIPTION
# Title

Add Java Blue-Gray to favourite colors.

## Purpose

- Add Java Blue-Gray to favourite colors.

## What

- Add Java Blue-Gray to favourite colors.

## How to Test

CMD + Shift + P (MacOS) or Ctrl + Shift + P (Win), Type Peacock: Change to favorite color > Java Blue-Gray

## What to Check

Verify that the following are valid

## Checklist of changes included

- [x] CHANGELOG updated
- [ ] README updated
- [ ] Tests updated/added
- [ ] Prettier formatting
- [ ] console.log removed
- [ ] Dead code removed
- [ ] Unnecessary comments removed
- [ ] Images updated (if applicable)
