### PR TITLE
Simplifying Live Share command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Peacock detects when the [Live Share](https://marketplace.visualstudio.com/items
 
 | Command                                                   | Description                                                                    |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Peacock: Change Color for when you are a Live Share Host  | Prompts user to select a color for Live Share Host session from the Favorites  |
-| Peacock: Change Color for when you are a Live Share Guest | Prompts user to select a color for Live Share Guest session from the Favorites |
+| Peacock: Change Live Share Color (Host)  | Prompts user to select a color for Live Share Host session from the Favorites  |
+| Peacock: Change Live Share Color (Guest) | Prompts user to select a color for Live Share Guest session from the Favorites |
 
 When a [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare&wt.mc_id=vscodepeacock-github-jopapa) session is started, the selected workspace color will be applied. When the session is finished, the workspace color is reverted back to the previous one (if set).
 

--- a/package.json
+++ b/package.json
@@ -71,12 +71,12 @@
       },
       {
         "command": "peacock.changeColorOfLiveShareHost",
-        "title": "Change Color for When You Are a Live Share Host",
+        "title": "Change Live Share Color (Host)",
         "category": "Peacock"
       },
       {
         "command": "peacock.changeColorOfLiveShareGuest",
-        "title": "Change Color for When You Are a Live Share Guest",
+        "title": "Change Live Share Color (Guest)",
         "category": "Peacock"
       }
     ],


### PR DESCRIPTION
This PR simplifies the command names for the new Live Share integration. After dogfooding it a little bit, I just personally found the current names to be a little too verbose.