### PR TITLE
[favourite color] revert to null color properly if command was cancelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -114,7 +114,7 @@ export async function updateWorkspaceConfiguration(
   return await workspace
     .getConfiguration()
     .update(
-      'workbench.colorCustomizations',
+      Sections.workspacePeacockSection,
       colorCustomizations,
       vscode.ConfigurationTarget.Workspace
     );

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,10 +1,20 @@
 import * as vscode from 'vscode';
-import { favoriteColorSeparator, peacockGreen } from './models';
+import { favoriteColorSeparator, peacockGreen, Sections } from './models';
 import {
   getFavoriteColors,
   getCurrentColorBeforeAdjustments
 } from './configuration';
 import { changeColor } from './color-library';
+
+export async function setPeacockColorCustomizations(colorCustomizations: any) {
+  await vscode.workspace
+    .getConfiguration()
+    .update(
+      Sections.workspacePeacockSection,
+      colorCustomizations,
+      vscode.ConfigurationTarget.Workspace
+    );
+}
 
 export async function promptForColor() {
   const options: vscode.InputBoxOptions = {
@@ -43,14 +53,20 @@ export async function promptForFavoriteColor() {
   if (favoriteColors && favoriteColors.length) {
     selection = (await vscode.window.showQuickPick(menu, options)) || '';
   }
-  if (!selection) {
-    // when there is no selection, revert to starting color
-    await changeColor(startingColor);
-    return '';
+  if (selection) {
+    let selectedColor = parseFavoriteColorValue(selection);
+    return selectedColor || '';
   }
 
-  let selectedColor = parseFavoriteColorValue(selection);
-  return selectedColor || '';
+  if (startingColor) {
+    // when there is no selection and startingColor, revert to starting color
+    await changeColor(startingColor);
+  } else {
+    // if no color was previously set, reset the current color to `null`
+    await setPeacockColorCustomizations(null);
+  }
+  
+  return '';
 }
 
 export function parseFavoriteColorValue(text: string) {

--- a/src/live-share/constants.ts
+++ b/src/live-share/constants.ts
@@ -1,7 +1,5 @@
 export const VSLS_SHARE_COLOR_MEMENTO_NAME = 'peacock.vsls.share.color';
 export const VSLS_JOIN_COLOR_MEMENTO_NAME = 'peacock.vsls.join.color';
-export const VSCODE_WORKSPACE_COLORS_SETTING_NAME =
-  'workbench.colorCustomizations';
 
 export enum LiveShareCommands {
   changeColorOfLiveShareHost = 'peacock.changeColorOfLiveShareHost',

--- a/src/live-share/constants.ts
+++ b/src/live-share/constants.ts
@@ -1,7 +1,2 @@
-export const VSLS_SHARE_COLOR_MEMENTO_NAME = 'peacock.vsls.share.color';
-export const VSLS_JOIN_COLOR_MEMENTO_NAME = 'peacock.vsls.join.color';
-
-export enum LiveShareCommands {
-  changeColorOfLiveShareHost = 'peacock.changeColorOfLiveShareHost',
-  changeColorOfLiveShareGuest = 'peacock.changeColorOfLiveShareGuest'
-}
+export const vslsShareColorMementoName = 'peacock.vsls.share.color';
+export const vslsJoinColorMementoName = 'peacock.vsls.join.color';

--- a/src/live-share/enums.ts
+++ b/src/live-share/enums.ts
@@ -1,0 +1,4 @@
+export enum LiveShareCommands {
+  changeColorOfLiveShareHost = 'peacock.changeColorOfLiveShareHost',
+  changeColorOfLiveShareGuest = 'peacock.changeColorOfLiveShareGuest'
+}

--- a/src/live-share/integration.ts
+++ b/src/live-share/integration.ts
@@ -2,8 +2,8 @@ import * as vsls from 'vsls';
 import * as vscode from 'vscode';
 
 import {
-  VSLS_SHARE_COLOR_MEMENTO_NAME,
-  VSLS_JOIN_COLOR_MEMENTO_NAME
+  vslsShareColorMementoName,
+  vslsJoinColorMementoName
 } from './constants';
 import { changeColor } from '../color-library';
 import { registerLiveShareIntegrationCommands } from './liveshare-commands';
@@ -21,8 +21,8 @@ export async function revertLiveShareWorkspaceColors() {
 
 async function setLiveShareSessionWorkspaceColors(isHost: boolean) {
   const colorSettingName = isHost
-    ? VSLS_SHARE_COLOR_MEMENTO_NAME
-    : VSLS_JOIN_COLOR_MEMENTO_NAME;
+    ? vslsShareColorMementoName
+    : vslsJoinColorMementoName;
 
   const liveShareColorSetting = await extensionContext.globalState.get<string>(
     colorSettingName

--- a/src/live-share/integration.ts
+++ b/src/live-share/integration.ts
@@ -3,22 +3,18 @@ import * as vscode from 'vscode';
 
 import {
   VSLS_SHARE_COLOR_MEMENTO_NAME,
-  VSLS_JOIN_COLOR_MEMENTO_NAME,
-  VSCODE_WORKSPACE_COLORS_SETTING_NAME
+  VSLS_JOIN_COLOR_MEMENTO_NAME
 } from './constants';
 import { changeColor } from '../color-library';
 import { registerLiveShareIntegrationCommands } from './liveshare-commands';
 import { extensionContext, setExtensionContext } from './extension-context';
+import { setPeacockColorCustomizations } from '../inputs';
+import { Sections } from '../models';
 
 let peacockColorCustomizations: any;
+
 export async function revertLiveShareWorkspaceColors() {
-  await vscode.workspace
-    .getConfiguration()
-    .update(
-      VSCODE_WORKSPACE_COLORS_SETTING_NAME,
-      peacockColorCustomizations,
-      vscode.ConfigurationTarget.Workspace
-    );
+  await setPeacockColorCustomizations(peacockColorCustomizations);
 
   peacockColorCustomizations = null;
 }
@@ -88,7 +84,7 @@ export async function addLiveShareIntegration(
     // to prevent the case of multiple color changes during live share session
     peacockColorCustomizations = await vscode.workspace
       .getConfiguration()
-      .get(VSCODE_WORKSPACE_COLORS_SETTING_NAME);
+      .get(Sections.workspacePeacockSection);
 
     const isHost = e.session.role === vsls.Role.Host;
     return await setLiveShareSessionWorkspaceColors(isHost);

--- a/src/live-share/liveshare-commands.ts
+++ b/src/live-share/liveshare-commands.ts
@@ -3,10 +3,10 @@ import { commands } from 'vscode';
 import { promptForFavoriteColor } from '../inputs';
 import { isValidColorInput, changeColor } from '../color-library';
 import {
-  VSLS_SHARE_COLOR_MEMENTO_NAME,
-  VSLS_JOIN_COLOR_MEMENTO_NAME,
-  LiveShareCommands
+  vslsShareColorMementoName,
+  vslsJoinColorMementoName
 } from './constants';
+import { LiveShareCommands } from './enums';
 import {
   refreshLiveShareSessionColor,
   revertLiveShareWorkspaceColors
@@ -21,8 +21,8 @@ const changeColorOfLiveShareSessionFactory = (isHost: boolean) => {
 
     if (isValidColorInput(input)) {
       const settingName = isHost
-        ? VSLS_SHARE_COLOR_MEMENTO_NAME
-        : VSLS_JOIN_COLOR_MEMENTO_NAME;
+        ? vslsShareColorMementoName
+        : vslsJoinColorMementoName;
 
       await extensionContext.globalState.update(settingName, input);
     }
@@ -67,8 +67,8 @@ export function registerLiveShareIntegrationCommands() {
 
 export async function resetLiveSharePreviousColors() {
   await extensionContext.globalState.update(
-    VSLS_SHARE_COLOR_MEMENTO_NAME,
+    vslsShareColorMementoName,
     null
   );
-  await extensionContext.globalState.update(VSLS_JOIN_COLOR_MEMENTO_NAME, null);
+  await extensionContext.globalState.update(vslsJoinColorMementoName, null);
 }

--- a/src/live-share/test/live-share.test.ts
+++ b/src/live-share/test/live-share.test.ts
@@ -9,10 +9,10 @@ import { isValidColorInput } from '../../color-library';
 import { executeCommand } from '../../test/lib/constants';
 import { getPeacockWorkspaceConfig } from '../../configuration';
 import {
-  LiveShareCommands,
-  VSLS_SHARE_COLOR_MEMENTO_NAME,
-  VSLS_JOIN_COLOR_MEMENTO_NAME
+  vslsShareColorMementoName,
+  vslsJoinColorMementoName
 } from '../constants';
+import { LiveShareCommands } from '../enums';
 
 const sleepAsync = (delay: number) => {
   return new Promise(resolve => {
@@ -38,10 +38,10 @@ suite('Live Share Integration', () => {
 
     const settingValue =
       (await extensionContext!.globalState.get<string>(
-        VSLS_SHARE_COLOR_MEMENTO_NAME
+        vslsShareColorMementoName
       )) || '';
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
 
@@ -65,10 +65,10 @@ suite('Live Share Integration', () => {
 
     const settingValue =
       (await extensionContext!.globalState.get<string>(
-        VSLS_JOIN_COLOR_MEMENTO_NAME
+        vslsJoinColorMementoName
       )) || '';
     await extensionContext!.globalState.update(
-      VSLS_JOIN_COLOR_MEMENTO_NAME,
+      vslsJoinColorMementoName,
       null
     );
 
@@ -104,7 +104,7 @@ suite('Live Share Integration', () => {
 
     await vslsApi.end();
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
 
@@ -139,7 +139,7 @@ suite('Live Share Integration', () => {
     const value = config[ColorSettings.titleBar_activeBackground];
 
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
 
@@ -172,7 +172,7 @@ suite('Live Share Integration', () => {
 
     await vslsApi.end();
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
 
@@ -223,7 +223,7 @@ suite('Live Share Integration', () => {
 
     await vslsApi.end();
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
   });
@@ -289,7 +289,7 @@ suite('Live Share Integration', () => {
     assert(value == null);
 
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
   });
@@ -364,7 +364,7 @@ suite('Live Share Integration', () => {
     assert(value === startColor);
 
     await extensionContext!.globalState.update(
-      VSLS_SHARE_COLOR_MEMENTO_NAME,
+      vslsShareColorMementoName,
       null
     );
   });

--- a/src/test/favorite-colors.test.ts
+++ b/src/test/favorite-colors.test.ts
@@ -49,4 +49,21 @@ suite('Favorite colors', () => {
 
     assert.ok(valueBefore === valueAfter);
   });
+
+  test('set to favorite color with no preferences is a noop, when color was not previously set', async () => {
+    // Stub the async quick pick to return a response
+    const fakeResponse = '';
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
+
+      let config = getPeacockWorkspaceConfig();
+    const valueBefore = config[ColorSettings.titleBar_activeBackground];
+    await executeCommand(Commands.changeColorToFavorite);
+    const value = config[ColorSettings.titleBar_activeBackground];
+    stub.restore();
+
+    assert.ok(!isValidColorInput(value));
+    assert.ok(value === valueBefore);
+  });
 });


### PR DESCRIPTION
The PR fixes the issue when after canceling the `>Peacock: Change to a Favorite Color` command, the color of the workspace is set to `black` and adds the appropriate test.

### Repro:
	1. Run `>Peacock: Change to a Favorite Color` command.
	2. Select a color from the list and press `ESC` to cancel the command.
	3. Notice that the color of the workspace is changed to `#000000` this happens since the `''` result from the canceled command is erroneously parsed as `'#000000'`.

![peacock-issue](https://user-images.githubusercontent.com/1478800/58779506-fdb52900-858a-11e9-85e1-d1d7ef39c27d.gif)

### Fix:

1. Check color input and if it is falsey, set the workspace color to `null`.

![peacock-solution](https://user-images.githubusercontent.com/1478800/58779568-33f2a880-858b-11e9-9fd8-c7476e32f431.gif)

