### PR TITLE
Surprise Me From Favorites Only or Randomly

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
           "default": true,
           "description": "Specifies whether Peacock should affect the title bar."
         },
+        "peacock.surpriseMeFromFavoritesOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether Peacock should choose a random color from the favorites list or a purely random color."
+        },
         "peacock.keepForegroundColor": {
           "type": "boolean",
           "default": false,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,7 +13,9 @@ import {
   getCurrentColorBeforeAdjustments,
   addNewFavoriteColor,
   writeRecommendedFavoriteColors,
-  getDarkenLightenPercentage
+  getDarkenLightenPercentage,
+  getRandomFavoriteColor,
+  getSurpriseMeFromFavoritesOnly
 } from './configuration';
 import {
   promptForColor,
@@ -63,7 +65,11 @@ export async function enterColorHandler(color?: string) {
 }
 
 export async function changeColorToRandomHandler() {
-  await changeColor(getRandomColorHex());
+  let surpriseMeFromFavoritesOnly = getSurpriseMeFromFavoritesOnly();
+  let color = surpriseMeFromFavoritesOnly
+    ? getRandomFavoriteColor().value
+    : getRandomColorHex();
+  await changeColor(color);
   return State.extensionContext;
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -260,6 +260,13 @@ export async function updateDarkenLightenPrecentage(value: number) {
   );
 }
 
+export async function updateSurpriseMeFromFavoritesOnly(value: boolean) {
+  return await updateGlobalConfiguration(
+    StandardSettings.SurpriseMeFromFavoritesOnly,
+    value
+  );
+}
+
 export async function addNewFavoriteColor(name: string, value: string) {
   const { values: favoriteColors } = getFavoriteColors();
   const newFavoriteColors = [...favoriteColors, { name, value }];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,6 +32,13 @@ import { Logger } from './logging';
 
 const { workspace } = vscode;
 
+export function getSurpriseMeFromFavoritesOnly() {
+  return readConfiguration<boolean>(
+    StandardSettings.SurpriseMeFromFavoritesOnly,
+    false
+  );
+}
+
 export function getDarkenLightenPercentage() {
   return readConfiguration<number>(
     StandardSettings.DarkenLightenPercentage,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -172,6 +172,13 @@ export function getFavoriteColors() {
   };
 }
 
+export function getRandomFavoriteColor() {
+  const { values: favoriteColors } = getFavoriteColors();
+  let randomFavorite =
+    favoriteColors[Math.floor(Math.random() * favoriteColors.length)];
+  return randomFavorite;
+}
+
 export function getSurpriseMeOnStartup() {
   return readConfiguration<boolean>(
     StandardSettings.SurpriseMeOnStartup,

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -6,7 +6,8 @@ export enum StandardSettings {
   SurpriseMeOnStartup = 'surpriseMeOnStartup',
   DarkForegroundColor = 'darkForegroundColor',
   LightForegroundColor = 'lightForegroundColor',
-  DarkenLightenPercentage = 'darkenLightenPercentage'
+  DarkenLightenPercentage = 'darkenLightenPercentage',
+  SurpriseMeFromFavoritesOnly = 'surpriseMeFromFavoritesOnly'
 }
 
 export enum AffectedSettings {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -50,6 +50,7 @@ export interface IPeacockSettings {
   darkForegroundColor: string;
   lightForegroundColor: string;
   darkenLightenPercentage: number;
+  surpriseMeFromFavoritesOnly: boolean;
 }
 
 export interface IElementColors {

--- a/src/test/built-in-colors.test.ts
+++ b/src/test/built-in-colors.test.ts
@@ -16,7 +16,10 @@ import { isValidColorInput } from '../color-library';
 import {
   getPeacockWorkspaceConfig,
   updateWorkspaceConfiguration,
-  getExistingColorCustomizations
+  getExistingColorCustomizations,
+  getCurrentColorBeforeAdjustments,
+  getFavoriteColors,
+  updateSurpriseMeFromFavoritesOnly
 } from '../configuration';
 
 suite('can set color to built-in color', () => {
@@ -28,12 +31,23 @@ suite('can set color to built-in color', () => {
 
   test('can set color to Peacock Green', testChangingColorToPeacockGreen());
 
-  test('can set color to Random color', async () => {
-    await executeCommand(Commands.changeColorToRandom);
-    let config = getPeacockWorkspaceConfig();
-    assert.ok(
-      isValidColorInput(config[ColorSettings.titleBar_activeBackground])
-    );
+  suite('can set color to Random color', () => {
+    test('color is valid', async () => {
+      await executeCommand(Commands.changeColorToRandom);
+      let config = getPeacockWorkspaceConfig();
+      assert.ok(
+        isValidColorInput(config[ColorSettings.titleBar_activeBackground])
+      );
+    });
+
+    test("when 'surprise me from favorites only' is true, color matches a favorite and is not chosen at random", async () => {
+      await updateSurpriseMeFromFavoritesOnly(true);
+      await executeCommand(Commands.changeColorToRandom);
+      const color = getCurrentColorBeforeAdjustments();
+      let { values } = getFavoriteColors();
+      const match = values.find(item => item.value === color);
+      assert.ok(match);
+    });
   });
 
   suite('when resetting colors', () => {

--- a/src/test/lib/setup-teardown-test-suite.ts
+++ b/src/test/lib/setup-teardown-test-suite.ts
@@ -18,20 +18,12 @@ import {
   getLightForegroundColor,
   updateDarkForegroundColor,
   updateLightForegroundColor,
-  updateAffectedElements
+  updateAffectedElements,
+  updateSurpriseMeFromFavoritesOnly,
+  getSurpriseMeFromFavoritesOnly
 } from '../../configuration';
 
 import { noopElementAdjustments, executeCommand } from './constants';
-
-export function allSetupAndTeardown(originalValues: IPeacockSettings) {
-  // suiteSetup(async () => {
-  //   await setupTestSuite(originalValues);
-  // });
-  // suiteTeardown(() => teardownTestSuite(originalValues));
-  // setup(async () => {
-  //   await executeCommand(Commands.resetColors);
-  // });
-}
 
 export async function setupTest() {
   await executeCommand(Commands.resetColors);
@@ -42,6 +34,7 @@ export async function setupTestSuite(
   originalValues: IPeacockSettings
 ) {
   let extension = getExtension();
+
   // Save the original values
   originalValues.affectedElements = getAffectedElements();
   originalValues.keepForegroundColor = getKeepForegroundColor();
@@ -49,6 +42,8 @@ export async function setupTestSuite(
   originalValues.favoriteColors = favoriteColors;
   originalValues.darkForegroundColor = getDarkForegroundColor();
   originalValues.lightForegroundColor = getLightForegroundColor();
+  originalValues.surpriseMeFromFavoritesOnly = getSurpriseMeFromFavoritesOnly();
+
   // Set the test values
   await updateAffectedElements(<IPeacockAffectedElementSettings>{
     statusBar: true,
@@ -61,11 +56,13 @@ export async function setupTestSuite(
   await updateElementAdjustments(noopElementAdjustments);
   await updateDarkForegroundColor(ForegroundColors.DarkForeground);
   await updateLightForegroundColor(ForegroundColors.LightForeground);
+  await updateSurpriseMeFromFavoritesOnly(false);
   return extension;
 }
 
 export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await executeCommand(Commands.resetColors);
+
   // put back the original peacock user settings
   await updateAffectedElements(originalValues.affectedElements);
   await updateElementAdjustments(originalValues.elementAdjustments);
@@ -74,4 +71,7 @@ export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await updateSurpriseMeOnStartup(originalValues.surpriseMeOnStartup);
   await updateDarkForegroundColor(originalValues.darkForegroundColor);
   await updateLightForegroundColor(originalValues.lightForegroundColor);
+  await updateSurpriseMeFromFavoritesOnly(
+    originalValues.surpriseMeFromFavoritesOnly
+  );
 }


### PR DESCRIPTION
Created a new setting for `surpriseMeFromFavoritesOnly`. Defaults to false for backwards compatibility.

When false, a color is chosen purely randomly.

When true, a favorite color is selected randomly