### PR TITLE
refactored the remote and live share mementos to be user settings. now people can see and edit their remote and live share settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,17 +9,21 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "workbench.colorCustomizations": {
-    "activityBar.background": "#103362",
+    "activityBar.background": "#174a8e",
     "activityBar.foreground": "#e7e7e7",
     "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#c01f64",
+    "activityBarBadge.background": "#e03f84",
     "activityBarBadge.foreground": "#e7e7e7",
-    "titleBar.activeBackground": "#091c36",
-    "titleBar.inactiveBackground": "#091c3699",
+    "titleBar.activeBackground": "#103362",
+    "titleBar.inactiveBackground": "#10336299",
     "titleBar.activeForeground": "#e7e7e7",
     "titleBar.inactiveForeground": "#e7e7e799",
-    "statusBar.background": "#091c36",
-    "statusBarItem.hoverBackground": "#103362",
-    "statusBar.foreground": "#e7e7e7"
+    "statusBar.background": "#103362",
+    "statusBarItem.hoverBackground": "#174a8e",
+    "statusBar.foreground": "#e7e7e7",
+    "panel.border": "#174a8e",
+    "sideBar.border": "#174a8e",
+    "editorGroup.border": "#174a8e",
+    "tab.activeBorder": "#174a8e"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ DevOps
 
 Refactoring
 
-- Removed remote colors from mementos and instead created user settings for these. Mementos are best for values the user cant see, while settings make it easier for the user to see them and modify them directly. This feels right for the remote colors.
+- Removed remote colors and live share colors from mementos and instead created user settings for these. Mementos are best for values the user cant see, while settings make it easier for the user to see them and modify them directly. This feels right for these colors.
   - `peacock.remoteContainersColor` - Peacock color when in a remote with a container.
   - `peacock.remoteSshColor` - Peacock color when using remote with ssh.
   - `peacock.remoteWslColor` - Peacock color when using remote with WSL
+  - `peacock.vslsShareColor` - Peacock color for Live Share Hosting
+  - `peacock.vslsJoinColor` - Peacock color for Live Share Joining
 
 ## 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ DevOps
 
 - [Adding code coverage and test reporting to Azure Pipelines](https://github.com/johnpapa/vscode-peacock/pull/219)
 
+Refactoring
+
+- Removed remote colors from mementos and instead created user settings for these. Mementos are best for values the user cant see, while settings make it easier for the user to see them and modify them directly. This feels right for the remote colors.
+  - `peacock.remoteContainersColor` - Peacock color when in a remote with a container.
+  - `peacock.remoteSshColor` - Peacock color when using remote with ssh.
+  - `peacock.remoteWslColor` - Peacock color when using remote with WSL
+
 ## 2.5.0
 
 Features

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Commands can be found in the command palette. Look for commands beginning with `
 | peacock.remoteContainersColor       | Peacock color when in a remote with a container.                                                        |
 | peacock.remoteSshColor              | Peacock color when using remote with ssh.                                                               |
 | peacock.remoteWslColor              | Peacock color when using remote with WSL                                                                |
+| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                               |
+| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                              |
 
 ### Favorite Colors
 
@@ -326,12 +328,10 @@ This list may change from version to version depending on the Peacock authoring 
 
 Peacock takes advantage of a series of mementos (values stored between sessions and not in settings). Some are global that affect all VS Code instances on the computer. Some are local to the workspace on the computer.
 
-| Name                               | Type      | Description                                                                                                             |
-| ---------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
-| peacockMementos.peacockColor       | Workspace | The most recently used Peacock color, but not remote or other secondary colors. Ideal when moving in and out of remote. |
-| peacockMementos.favoritesVersion   | Global    | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings              |
-| peacockVslsMementos.vslsJoinColor  | Global    | VS Live Share's Peacock color when joining a session.                                                                   |
-| peacockVslsMementos.vslsShareColor | Global    | VS Live Share's Peacock color when sharing a session.                                                                   |
+| Name                             | Type      | Description                                                                                                             |
+| -------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| peacockMementos.peacockColor     | Workspace | The most recently used Peacock color, but not remote or other secondary colors. Ideal when moving in and out of remote. |
+| peacockMementos.favoritesVersion | Global    | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings              |
 
 ![Sketchnote](./resources/peacock-sketchnote.png)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Commands can be found in the command palette. Look for commands beginning with `
 | peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                           |
 | peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color |
 | peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                |
+| peacock.remoteContainersColor       | Peacock color when in a remote with a container.                                                        |
+| peacock.remoteSshColor              | Peacock color when using remote with ssh.                                                               |
+| peacock.remoteWslColor              | Peacock color when using remote with WSL                                                                |
 
 ### Favorite Colors
 
@@ -323,15 +326,12 @@ This list may change from version to version depending on the Peacock authoring 
 
 Peacock takes advantage of a series of mementos (values stored between sessions and not in settings). Some are global that affect all VS Code instances on the computer. Some are local to the workspace on the computer.
 
-| Name                                        | Type      | Description                                                                                                             |
-| ------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
-| peacockMementos.peacockColor                | Workspace | The most recently used Peacock color, but not remote or other secondary colors. Ideal when moving in and out of remote. |
-| peacockMementos.favoritesVersion            | Global    | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings              |
-| peacockVslsMementos.vslsJoinColor           | Global    | VS Live Share's Peacock color when joining a session.                                                                   |
-| peacockVslsMementos.vslsShareColor          | Global    | VS Live Share's Peacock color when sharing a session.                                                                   |
-| peacockRemoteMementos.remoteContainersColor | Global    | Peacock color when in a remote with a container.                                                                        |
-| peacockRemoteMementos.remoteSshColor        | Global    | Peacock color when using remote with ssh.                                                                               |
-| peacockRemoteMementos.remoteWslColor        | Global    | Peacock color when using remote with WSL                                                                                |
+| Name                               | Type      | Description                                                                                                             |
+| ---------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| peacockMementos.peacockColor       | Workspace | The most recently used Peacock color, but not remote or other secondary colors. Ideal when moving in and out of remote. |
+| peacockMementos.favoritesVersion   | Global    | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings              |
+| peacockVslsMementos.vslsJoinColor  | Global    | VS Live Share's Peacock color when joining a session.                                                                   |
+| peacockVslsMementos.vslsShareColor | Global    | VS Live Share's Peacock color when sharing a session.                                                                   |
 
 ![Sketchnote](./resources/peacock-sketchnote.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-peacock",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2094,7 +2094,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2115,12 +2116,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2135,17 +2138,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2262,7 +2268,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2274,6 +2281,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2288,6 +2296,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2295,12 +2304,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2319,6 +2330,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2399,7 +2411,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2411,6 +2424,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2496,7 +2510,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2532,6 +2547,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2551,6 +2567,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2594,12 +2611,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
         "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -191,14 +199,6 @@
         "@types/babel-types": "*",
         "@types/istanbul-lib-coverage": "*",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@types/istanbul-lib-report": {
@@ -218,14 +218,6 @@
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@types/istanbul-reports": {
@@ -237,6 +229,12 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -274,67 +272,49 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz",
-      "integrity": "sha512-J/ZTZF+pLNqjXBGNfq5fahsoJ4vJOkYbitWPavA05IrZ7BXUaf4XWlhUB/ic1lpOGTRpLWF+PLAePjiHp6dz8g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
+      "integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "1.12.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
         "eslint-utils": "^1.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
         "tsutils": "^3.7.0"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
-          "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.12.0.tgz",
-      "integrity": "sha512-s0soOTMJloytr9GbPteMLNiO2HvJ+qgQkRNplABXiVw6vq7uQRvidkby64Gqt/nA7pys74HksHwRULaB/QRVyw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.12.0",
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-scope": "^4.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.12.0.tgz",
-      "integrity": "sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.12.0",
-        "@typescript-eslint/typescript-estree": "1.12.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.12.0.tgz",
-      "integrity": "sha512-nwN6yy//XcVhFs0ZyU+teJHB8tbCm7AIA8mu6E2r5hu6MajwYBY3Uwop7+rPZWUN/IUOHpL8C+iUPMDVYUU3og==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
         "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
       }
     },
     "@webassemblyjs/ast": {
@@ -526,9 +506,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1067,6 +1047,29 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        }
       }
     },
     "chownr": {
@@ -1141,6 +1144,17 @@
         "string-width": "^2.1.1",
         "strip-ansi": "^4.0.0",
         "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "code-point-at": {
@@ -1572,9 +1586,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
-      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+      "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1583,7 +1597,7 @@
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
+        "eslint-scope": "^5.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
         "espree": "^6.0.0",
@@ -1591,28 +1605,47 @@
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "^5.0.0",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
+        "inquirer": "^6.4.1",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "eslint-config-prettier": {
@@ -2676,24 +2709,12 @@
       }
     },
     "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
@@ -2759,14 +2780,6 @@
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "has": {
@@ -3022,23 +3035,6 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "interpret": {
@@ -3295,9 +3291,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -3335,14 +3331,6 @@
         "make-dir": "^2.1.0",
         "rimraf": "^2.6.3",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
@@ -3513,6 +3501,14 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "mamacro": {
@@ -3757,6 +3753,12 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
         "supports-color": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -3880,6 +3882,14 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "node-libs-browser": {
@@ -4648,9 +4658,9 @@
       }
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "serialize-javascript": {
@@ -4799,6 +4809,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -4886,9 +4902,9 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "source-map-resolve": {
@@ -4912,14 +4928,6 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "source-map-url": {
@@ -5020,6 +5028,17 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -5032,12 +5051,20 @@
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
       }
     },
     "strip-eof": {
@@ -5047,9 +5074,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
     "supports-color": {
@@ -5073,12 +5100,6 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -5088,15 +5109,6 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -5116,14 +5128,6 @@
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
         "source-map-support": "~0.5.12"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "terser-webpack-plugin": {
@@ -5142,14 +5146,6 @@
         "terser": "^4.0.0",
         "webpack-sources": "^1.3.0",
         "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "text-table": {
@@ -5301,12 +5297,23 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "tsutils": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
+      "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -5354,15 +5361,6 @@
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "union-value": {
@@ -5548,9 +5546,9 @@
       }
     },
     "webpack": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.36.1.tgz",
-      "integrity": "sha512-Ej01/N9W8DVyhEpeQnbUdGvOECw0L46FxS12cCOs8gSK7bhUlrbHRnWkjiXckGlHjUrmL89kDpTRIkUk6Y+fKg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.37.0.tgz",
+      "integrity": "sha512-iJPPvL7XpbcbwOthbzpa2BSPlmGp8lGDokAj/LdWtK80rsPoPOdANSbDBf2GAVLKZD3GhCuQ/gGkgN9HWs0Keg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -5597,12 +5595,6 @@
         "yargs": "13.2.4"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -5623,15 +5615,6 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -5693,14 +5676,6 @@
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "which": {
@@ -5841,12 +5816,6 @@
         "yargs-parser": "^13.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -5856,15 +5825,6 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -255,6 +255,21 @@
           "type": "boolean",
           "default": false,
           "description": "Specifies that Peacock should surprise you at the start of every editing session"
+        },
+        "peacock.remoteContainersColor": {
+          "type": "string",
+          "default": "",
+          "description": "Peacock color when in a remote with a container"
+        },
+        "peacock.remoteSshColor": {
+          "type": "string",
+          "default": "",
+          "description": "Peacock color when using remote with ssh"
+        },
+        "peacock.remoteWslColor": {
+          "type": "string",
+          "default": "",
+          "description": "Peacock color when using remote with WSL"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
         "category": "Peacock"
       },
       {
+        "command": "peacock.changeColorOfLiveShareGuest",
+        "title": "Change Live Share Color (Guest)",
+        "category": "Peacock"
+      },
+      {
         "command": "peacock.darken",
         "title": "Darken",
         "category": "Peacock"
@@ -82,11 +87,6 @@
       {
         "command": "peacock.lighten",
         "title": "Lighten",
-        "category": "Peacock"
-      },
-      {
-        "command": "peacock.changeColorOfLiveShareGuest",
-        "title": "Change Live Share Color (Guest)",
         "category": "Peacock"
       },
       {
@@ -270,6 +270,16 @@
           "type": "string",
           "default": "",
           "description": "Peacock color when using remote with WSL"
+        },
+        "peacock.vslsShareColor": {
+          "type": "string",
+          "default": "",
+          "description": "Peacock color for Live Share Color when acting as a Host "
+        },
+        "peacock.vslsJoinColor": {
+          "type": "string",
+          "default": "",
+          "description": "Peacock color for Live Share Color when acting as a Guest "
         }
       }
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,7 +124,7 @@ export async function lightenHandler() {
 export async function showAndCopyCurrentColorHandler() {
   const color = State.recentColor;
   const msg = color
-    ? `The current Peacock color is ${color}`
+    ? `The current Peacock color is ${color} and has been copied to your clipboard.`
     : 'There is no Peacock color set at this time.';
   vscode.env.clipboard.writeText(color);
   notify(msg, true);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,7 +24,6 @@ import { resetRemotePreviousColors } from './remote';
 import { resetMementos } from './mementos';
 import { notify } from './notification';
 import { clearStatusBar } from './statusbar';
-import { workspace } from 'vscode';
 import * as vscode from 'vscode';
 
 export async function resetColorsHandler() {

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -27,6 +27,7 @@ import {
   getInactiveBackgroundColorHex,
   getInactiveForegroundColorHex,
 } from '../color-library';
+import { RemoteSettings } from '../remote/enums';
 
 const { workspace } = vscode;
 
@@ -105,6 +106,10 @@ export function prepareColors(backgroundHex: string) {
 
 export function getDarkForegroundColor() {
   return readConfiguration<string>(StandardSettings.DarkForegroundColor, '');
+}
+
+export function getRemoteColor(remoteSetting: RemoteSettings) {
+  return readConfiguration<string>(remoteSetting, '');
 }
 
 export function getDarkForegroundColorOrOverride() {

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -28,6 +28,7 @@ import {
   getInactiveForegroundColorHex,
 } from '../color-library';
 import { RemoteSettings } from '../remote/enums';
+import { LiveShareSettings } from '../live-share/enums';
 
 const { workspace } = vscode;
 
@@ -110,6 +111,10 @@ export function getDarkForegroundColor() {
 
 export function getRemoteColor(remoteSetting: RemoteSettings) {
   return readConfiguration<string>(remoteSetting, '');
+}
+
+export function getLiveShareColor(liveShareSetting: LiveShareSettings) {
+  return readConfiguration<string>(liveShareSetting, '');
 }
 
 export function getDarkForegroundColorOrOverride() {

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -14,6 +14,7 @@ import {
 import { Logger } from '../logging';
 import { getFavoriteColors } from './read-configuration';
 import { notify } from '../notification';
+import { RemoteSettings } from '../remote/enums';
 
 export async function updateGlobalConfiguration<T>(setting: AllSettings, value?: any) {
   let config = vscode.workspace.getConfiguration();
@@ -93,6 +94,10 @@ export async function writeRecommendedFavoriteColors(overrideFavorites?: IFavori
 
 export async function updateFavoriteColors(values: IFavoriteColors[]) {
   return await updateGlobalConfiguration(StandardSettings.FavoriteColors, values);
+}
+
+export async function updateRemoteColor(remoteSetting: RemoteSettings, color: string) {
+  return await updateGlobalConfiguration(remoteSetting, color);
 }
 
 export async function updateAffectedElements(values: IPeacockAffectedElementSettings) {

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -15,6 +15,7 @@ import { Logger } from '../logging';
 import { getFavoriteColors } from './read-configuration';
 import { notify } from '../notification';
 import { RemoteSettings } from '../remote/enums';
+import { LiveShareSettings } from '../live-share/enums';
 
 export async function updateGlobalConfiguration<T>(setting: AllSettings, value?: any) {
   let config = vscode.workspace.getConfiguration();
@@ -85,7 +86,9 @@ export async function addNewFavoriteColor(name: string, value: string) {
 }
 
 export async function writeRecommendedFavoriteColors(overrideFavorites?: IFavoriteColors[]) {
-  let msg = `${extensionShortName}: Adding recommended favorite colors to user settings for version ${State.extensionVersion}`;
+  let msg = `${extensionShortName}: Adding recommended favorite colors to user settings for version ${
+    State.extensionVersion
+  }`;
   notify(msg, true);
 
   const newFavoriteColors = removeDuplicatesToStarterSet(overrideFavorites);
@@ -98,6 +101,10 @@ export async function updateFavoriteColors(values: IFavoriteColors[]) {
 
 export async function updateRemoteColor(remoteSetting: RemoteSettings, color: string) {
   return await updateGlobalConfiguration(remoteSetting, color);
+}
+
+export async function updateLiveShareColor(liveShareSetting: LiveShareSettings, color: string) {
+  return await updateGlobalConfiguration(liveShareSetting, color);
 }
 
 export async function updateAffectedElements(values: IPeacockAffectedElementSettings) {

--- a/src/live-share/constants.ts
+++ b/src/live-share/constants.ts
@@ -1,7 +1,0 @@
-/* istanbul ignore file */
-import { extensionShortName } from '../models';
-
-export const peacockVslsMementos = {
-  vslsShareColor: `${extensionShortName}.vsls.share.color`,
-  vslsJoinColor: `${extensionShortName}.vsls.join.color`,
-};

--- a/src/live-share/enums.ts
+++ b/src/live-share/enums.ts
@@ -3,3 +3,8 @@ export enum LiveShareCommands {
   changeColorOfLiveShareHost = 'peacock.changeColorOfLiveShareHost',
   changeColorOfLiveShareGuest = 'peacock.changeColorOfLiveShareGuest',
 }
+
+export enum LiveShareSettings {
+  VSLSShareColor = 'vslsShareColor',
+  VSLSJoinColor = 'vslsJoinColor',
+}

--- a/src/live-share/integration.ts
+++ b/src/live-share/integration.ts
@@ -2,12 +2,13 @@
 import * as vsls from 'vsls';
 import * as vscode from 'vscode';
 
-import { peacockVslsMementos } from './constants';
 import { changeColor } from '../color-library';
 import { registerLiveShareIntegrationCommands } from './liveshare-commands';
 import { setPeacockColorCustomizations } from '../inputs';
-import { Sections, State } from '../models';
+import { State } from '../models';
 import { notify } from '../notification';
+import { LiveShareSettings } from './enums';
+import { getLiveShareColor, getExistingColorCustomizations } from '../configuration';
 
 let peacockColorCustomizations: any;
 
@@ -19,12 +20,10 @@ export async function revertLiveShareWorkspaceColors() {
 
 async function setLiveShareSessionWorkspaceColors(isHost: boolean) {
   const colorSettingName = isHost
-    ? peacockVslsMementos.vslsShareColor
-    : peacockVslsMementos.vslsJoinColor;
+    ? LiveShareSettings.VSLSShareColor
+    : LiveShareSettings.VSLSJoinColor;
 
-  const liveShareColorSetting = await State.extensionContext.globalState.get<string>(
-    colorSettingName,
-  );
+  const liveShareColorSetting = getLiveShareColor(colorSettingName);
   if (!liveShareColorSetting) {
     return;
   }
@@ -70,9 +69,7 @@ export async function addLiveShareIntegration(context: vscode.ExtensionContext) 
 
     // we need to update `peacockColorCustomizations` only when it is `undefined`
     // to prevent the case of multiple color changes during live share session
-    peacockColorCustomizations = await vscode.workspace
-      .getConfiguration()
-      .get(Sections.workspacePeacockSection);
+    peacockColorCustomizations = await getExistingColorCustomizations();
 
     const isHost = e.session.role === vsls.Role.Host;
     return await setLiveShareSessionWorkspaceColors(isHost);

--- a/src/live-share/liveshare-commands.ts
+++ b/src/live-share/liveshare-commands.ts
@@ -3,11 +3,9 @@ import { commands } from 'vscode';
 
 import { promptForFavoriteColor } from '../inputs';
 import { isValidColorInput, changeColor } from '../color-library';
-import { peacockVslsMementos } from './constants';
-import { LiveShareCommands } from './enums';
+import { LiveShareCommands, LiveShareSettings } from './enums';
 import { refreshLiveShareSessionColor, revertLiveShareWorkspaceColors } from './integration';
-import { getCurrentColorBeforeAdjustments } from '../configuration';
-import { saveGlobalMemento } from '../mementos';
+import { getCurrentColorBeforeAdjustments, updateLiveShareColor } from '../configuration';
 import { State } from '../models';
 
 const changeColorOfLiveShareSessionFactory = (isHost: boolean) => {
@@ -17,10 +15,10 @@ const changeColorOfLiveShareSessionFactory = (isHost: boolean) => {
 
     if (isValidColorInput(input)) {
       const settingName = isHost
-        ? peacockVslsMementos.vslsShareColor
-        : peacockVslsMementos.vslsJoinColor;
+        ? LiveShareSettings.VSLSShareColor
+        : LiveShareSettings.VSLSJoinColor;
 
-      await saveGlobalMemento(settingName, input);
+      await updateLiveShareColor(settingName, input);
     }
 
     const isRefreshed = await refreshLiveShareSessionColor(isHost);
@@ -58,6 +56,6 @@ export function registerLiveShareIntegrationCommands() {
 }
 
 export async function resetLiveSharePreviousColors() {
-  await saveGlobalMemento(peacockVslsMementos.vslsShareColor, null);
-  await saveGlobalMemento(peacockVslsMementos.vslsJoinColor, null);
+  await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
+  await updateLiveShareColor(LiveShareSettings.VSLSJoinColor, '');
 }

--- a/src/live-share/test/suite/live-share.test.ts
+++ b/src/live-share/test/suite/live-share.test.ts
@@ -3,7 +3,7 @@ import sinon = require('sinon');
 import assert = require('assert');
 import * as vsls from 'vsls';
 
-import { IPeacockSettings, Commands, ColorSettings, timeout, azureBlue } from '../../../models';
+import { IPeacockSettings, Commands, ColorSettings, timeout } from '../../../models';
 import {
   setupTestSuite,
   teardownTestSuite,
@@ -14,53 +14,47 @@ import { executeCommand } from '../../../test/suite/lib/constants';
 import { LiveShareCommands, LiveShareSettings } from '../../enums';
 import {
   getPeacockWorkspaceConfig,
-  getLiveShareColor,
   updateLiveShareColor,
+  getLiveShareColor,
 } from '../../../configuration';
 
 suite('Live Share Integration', () => {
   let originalValues = <IPeacockSettings>{};
-  let extensionContext: vscode.ExtensionContext | undefined;
 
   suiteSetup(async () => await setupTestSuite(originalValues));
   suiteTeardown(async () => await teardownTestSuite(originalValues));
   setup(async () => await setupTest());
 
-  setup(async () => {
-    extensionContext = await executeCommand<vscode.ExtensionContext>(
-      LiveShareCommands.changeColorOfLiveShareHost,
-    );
-  });
-
-  teardown(async () => {
-    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
-  });
-
   test('can set color setting for Live Share host', async () => {
     // Stub the async quick pick to return a response
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
-
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     const settingValue = getLiveShareColor(LiveShareSettings.VSLSShareColor) || '';
-
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
     stub.restore();
 
     assert(isValidColorInput(settingValue));
-    assert(settingValue === azureBlue);
+    assert(settingValue === color);
   });
 
   test('can set color setting for Live Share guest', async () => {
     // Stub the async quick pick to return a response
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
-
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareGuest);
     const settingValue = getLiveShareColor(LiveShareSettings.VSLSJoinColor) || '';
     await updateLiveShareColor(LiveShareSettings.VSLSJoinColor, '');
-
     stub.restore();
 
     assert(isValidColorInput(settingValue));
-    assert(settingValue === azureBlue);
+    assert(settingValue === color);
   });
 
   test('Workspace color is updated when Live Share session is started.', async () => {
@@ -70,9 +64,12 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
-
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
     await vslsApi.share();
@@ -82,9 +79,10 @@ suite('Live Share Integration', () => {
     const value = config[ColorSettings.titleBar_activeBackground];
 
     await vslsApi.end();
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
     assert(isValidColorInput(value));
-    assert(value === azureBlue);
+    assert(value === color);
   });
 
   test('Workspace color is reverted when Live Share session is ended.', async () => {
@@ -94,9 +92,13 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
 
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
     await vslsApi.share();
@@ -107,7 +109,7 @@ suite('Live Share Integration', () => {
     let config = getPeacockWorkspaceConfig();
     const value = config[ColorSettings.titleBar_activeBackground];
 
-    // await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
     assert(!isValidColorInput(value));
     assert(value == null);
@@ -122,18 +124,23 @@ suite('Live Share Integration', () => {
 
     await vslsApi.share();
 
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
 
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
     let config = getPeacockWorkspaceConfig();
     const value = config[ColorSettings.titleBar_activeBackground];
 
     await vslsApi.end();
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
     assert(isValidColorInput(value));
-    assert(value === azureBlue);
+    assert(value === color);
   });
 
   test('Workspace color is immediately reflected when updated during Live Share session.', async () => {
@@ -142,9 +149,14 @@ suite('Live Share Integration', () => {
     if (!vslsApi) {
       throw new Error('Live Share extension is not installed.');
     }
-    const fakeResponse = `Azure Blue -> ${azureBlue}`;
-    const stub = await stubQickPick(fakeResponse);
 
+    const color = '#007fff';
+    const fakeResponse = `Azure Blue -> ${color}`;
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
+
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
     await vslsApi.share();
@@ -153,9 +165,11 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await stubQickPick(fakeResponse2);
+    const stub2 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse2));
 
-    await executeCommand<vscode.ExtensionContext>(LiveShareCommands.changeColorOfLiveShareHost);
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
 
     await timeout(1000);
@@ -167,7 +181,7 @@ suite('Live Share Integration', () => {
     assert(value === color2);
 
     await vslsApi.end();
-    // await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
   });
 
   test('Workspace color is reverted after Live Share session when updated the color multiple times.', async () => {
@@ -183,26 +197,33 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await stubQickPick(fakeResponse2);
+    const stub2 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse2));
 
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
 
     await timeout(1000);
 
     const color3 = '#b52e31';
     const fakeResponse3 = `Angular Red -> ${color3}`;
-    const stub3 = await stubQickPick(fakeResponse3);
+    const stub3 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse3));
 
-    await executeCommand<vscode.ExtensionContext>(LiveShareCommands.changeColorOfLiveShareHost);
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub3.restore();
 
     await timeout(1000);
 
     const color4 = '#639';
     const fakeResponse4 = `Gatsby Purple -> ${color4}`;
-    const stub4 = await stubQickPick(fakeResponse4);
+    const stub4 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse4));
 
-    await executeCommand<vscode.ExtensionContext>(LiveShareCommands.changeColorOfLiveShareHost);
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub4.restore();
 
     await timeout(1000);
@@ -217,7 +238,7 @@ suite('Live Share Integration', () => {
     assert(!isValidColorInput(value));
     assert(value == null);
 
-    // await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
   });
 
   test('Workspace color is reverted to a preset color after Live Share session when updated the color multiple times.', async () => {
@@ -227,9 +248,11 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const startColor = azureBlue;
+    const startColor = '#007fff';
     const fakeResponse = `Azure Blue -> ${startColor}`;
-    const stub = await stubQickPick(fakeResponse);
+    const stub = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse));
 
     await executeCommand(Commands.changeColorToFavorite);
     stub.restore();
@@ -240,26 +263,33 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await stubQickPick(fakeResponse2);
+    const stub2 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse2));
 
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
 
     await timeout(1000);
 
     const color3 = '#b52e31';
-    const fakeResponse3 = `Abgular Red -> ${color3}`;
-    const stub3 = await stubQickPick(fakeResponse3);
+    const fakeResponse3 = `Angular Red -> ${color3}`;
+    const stub3 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse3));
 
-    await executeCommand<vscode.ExtensionContext>(LiveShareCommands.changeColorOfLiveShareHost);
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub3.restore();
 
     await timeout(1000);
 
     const color4 = '#639';
     const fakeResponse4 = `Gatsby Purple -> ${color4}`;
-    const stub4 = await stubQickPick(fakeResponse4);
+    const stub4 = await sinon
+      .stub(vscode.window, 'showQuickPick')
+      .returns(Promise.resolve<any>(fakeResponse4));
 
-    await executeCommand<vscode.ExtensionContext>(LiveShareCommands.changeColorOfLiveShareHost);
+    await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub4.restore();
 
     await timeout(1000);
@@ -274,13 +304,9 @@ suite('Live Share Integration', () => {
     assert(isValidColorInput(value));
     assert(value === startColor);
 
-    // await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
+    await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
   });
 });
 
-const stubQickPick = async (fakeResponse: string) => {
-  const stub = await sinon
-    .stub(vscode.window, 'showQuickPick')
-    .returns(Promise.resolve<any>(fakeResponse));
-  return stub;
-};
+const stubQuickPick = async (fakeResponse: string) =>
+  await sinon.stub(vscode.window, 'showQuickPick').returns(Promise.resolve<any>(fakeResponse));

--- a/src/live-share/test/suite/live-share.test.ts
+++ b/src/live-share/test/suite/live-share.test.ts
@@ -3,7 +3,7 @@ import sinon = require('sinon');
 import assert = require('assert');
 import * as vsls from 'vsls';
 
-import { IPeacockSettings, Commands, ColorSettings, timeout } from '../../../models';
+import { IPeacockSettings, Commands, ColorSettings, timeout, azureBlue } from '../../../models';
 import {
   setupTestSuite,
   teardownTestSuite,
@@ -26,35 +26,27 @@ suite('Live Share Integration', () => {
   setup(async () => await setupTest());
 
   test('can set color setting for Live Share host', async () => {
-    // Stub the async quick pick to return a response
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     const settingValue = getLiveShareColor(LiveShareSettings.VSLSShareColor) || '';
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
     stub.restore();
 
-    assert(isValidColorInput(settingValue));
-    assert(settingValue === color);
+    assert.ok(isValidColorInput(settingValue));
+    assert.equal(settingValue, azureBlue);
   });
 
   test('can set color setting for Live Share guest', async () => {
-    // Stub the async quick pick to return a response
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareGuest);
     const settingValue = getLiveShareColor(LiveShareSettings.VSLSJoinColor) || '';
     await updateLiveShareColor(LiveShareSettings.VSLSJoinColor, '');
     stub.restore();
 
-    assert(isValidColorInput(settingValue));
-    assert(settingValue === color);
+    assert.ok(isValidColorInput(settingValue));
+    assert.equal(settingValue, azureBlue);
   });
 
   test('Workspace color is updated when Live Share session is started.', async () => {
@@ -64,11 +56,8 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
@@ -81,8 +70,8 @@ suite('Live Share Integration', () => {
     await vslsApi.end();
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
-    assert(isValidColorInput(value));
-    assert(value === color);
+    assert.ok(isValidColorInput(value));
+    assert.equal(value, azureBlue);
   });
 
   test('Workspace color is reverted when Live Share session is ended.', async () => {
@@ -92,12 +81,8 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
-
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
@@ -111,8 +96,8 @@ suite('Live Share Integration', () => {
 
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
-    assert(!isValidColorInput(value));
-    assert(value == null);
+    assert.ok(!isValidColorInput(value));
+    assert.ok(!value);
   });
 
   test('Workspace color is immediately reflected when set during Live Share session.', async () => {
@@ -124,12 +109,8 @@ suite('Live Share Integration', () => {
 
     await vslsApi.share();
 
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
-
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
@@ -139,8 +120,8 @@ suite('Live Share Integration', () => {
     await vslsApi.end();
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
 
-    assert(isValidColorInput(value));
-    assert(value === color);
+    assert.ok(isValidColorInput(value));
+    assert.equal(value, azureBlue);
   });
 
   test('Workspace color is immediately reflected when updated during Live Share session.', async () => {
@@ -150,12 +131,8 @@ suite('Live Share Integration', () => {
       throw new Error('Live Share extension is not installed.');
     }
 
-    const color = '#007fff';
-    const fakeResponse = `Azure Blue -> ${color}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
-
+    const fakeResponse = `Azure Blue -> ${azureBlue}`;
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub.restore();
 
@@ -165,10 +142,7 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse2));
-
+    const stub2 = await stubQuickPick(fakeResponse2);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
 
@@ -177,8 +151,8 @@ suite('Live Share Integration', () => {
     let config = getPeacockWorkspaceConfig();
     const value = config[ColorSettings.titleBar_activeBackground] as string;
 
-    assert(isValidColorInput(value));
-    assert(value === color2);
+    assert.ok(isValidColorInput(value));
+    assert.equal(value, color2);
 
     await vslsApi.end();
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
@@ -197,9 +171,7 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse2));
+    const stub2 = await stubQuickPick(fakeResponse2);
 
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
@@ -208,9 +180,7 @@ suite('Live Share Integration', () => {
 
     const color3 = '#b52e31';
     const fakeResponse3 = `Angular Red -> ${color3}`;
-    const stub3 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse3));
+    const stub3 = await stubQuickPick(fakeResponse3);
 
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub3.restore();
@@ -219,10 +189,7 @@ suite('Live Share Integration', () => {
 
     const color4 = '#639';
     const fakeResponse4 = `Gatsby Purple -> ${color4}`;
-    const stub4 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse4));
-
+    const stub4 = await stubQuickPick(fakeResponse4);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub4.restore();
 
@@ -235,8 +202,8 @@ suite('Live Share Integration', () => {
     let config = getPeacockWorkspaceConfig();
     const value = config[ColorSettings.titleBar_activeBackground] as string;
 
-    assert(!isValidColorInput(value));
-    assert(value == null);
+    assert.ok(!isValidColorInput(value));
+    assert.ok(!value);
 
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
   });
@@ -250,10 +217,7 @@ suite('Live Share Integration', () => {
 
     const startColor = '#007fff';
     const fakeResponse = `Azure Blue -> ${startColor}`;
-    const stub = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse));
-
+    const stub = await stubQuickPick(fakeResponse);
     await executeCommand(Commands.changeColorToFavorite);
     stub.restore();
 
@@ -263,10 +227,7 @@ suite('Live Share Integration', () => {
 
     const color2 = '#68217a';
     const fakeResponse2 = `C# Purple -> ${color2}`;
-    const stub2 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse2));
-
+    const stub2 = await stubQuickPick(fakeResponse2);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub2.restore();
 
@@ -274,10 +235,7 @@ suite('Live Share Integration', () => {
 
     const color3 = '#b52e31';
     const fakeResponse3 = `Angular Red -> ${color3}`;
-    const stub3 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse3));
-
+    const stub3 = await stubQuickPick(fakeResponse3);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub3.restore();
 
@@ -285,10 +243,7 @@ suite('Live Share Integration', () => {
 
     const color4 = '#639';
     const fakeResponse4 = `Gatsby Purple -> ${color4}`;
-    const stub4 = await sinon
-      .stub(vscode.window, 'showQuickPick')
-      .returns(Promise.resolve<any>(fakeResponse4));
-
+    const stub4 = await stubQuickPick(fakeResponse4);
     await executeCommand(LiveShareCommands.changeColorOfLiveShareHost);
     stub4.restore();
 
@@ -301,8 +256,8 @@ suite('Live Share Integration', () => {
     let config = getPeacockWorkspaceConfig();
     const value = config[ColorSettings.titleBar_activeBackground] as string;
 
-    assert(isValidColorInput(value));
-    assert(value === startColor);
+    assert.ok(isValidColorInput(value));
+    assert.equal(value, startColor);
 
     await updateLiveShareColor(LiveShareSettings.VSLSShareColor, '');
   });

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -1,7 +1,6 @@
 import { isValidColorInput } from './color-library';
 import { peacockMementos, extensionShortName, State } from './models';
 import { Logger } from './logging';
-import { peacockVslsMementos } from './live-share/constants';
 
 export interface IMementoLog {
   name: string;
@@ -55,9 +54,6 @@ export async function resetMementos() {
   // Global
   await ec.globalState.update(peacockMementos.favoritesVersion, undefined);
 
-  await ec.globalState.update(peacockVslsMementos.vslsJoinColor, undefined);
-  await ec.globalState.update(peacockVslsMementos.vslsShareColor, undefined);
-
   // Workspace
   await ec.workspaceState.update(peacockMementos.peacockColor, undefined);
 }
@@ -71,16 +67,6 @@ export function getMementos() {
     name: peacockMementos.favoritesVersion,
     type: 'globalState',
     value: ec.globalState.get(peacockMementos.favoritesVersion),
-  });
-  mementos.push({
-    name: peacockVslsMementos.vslsJoinColor,
-    type: 'globalState',
-    value: ec.globalState.get(peacockVslsMementos.vslsJoinColor),
-  });
-  mementos.push({
-    name: peacockVslsMementos.vslsShareColor,
-    type: 'globalState',
-    value: ec.globalState.get(peacockVslsMementos.vslsShareColor),
   });
 
   // Workspace

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -2,7 +2,6 @@ import { isValidColorInput } from './color-library';
 import { peacockMementos, extensionShortName, State } from './models';
 import { Logger } from './logging';
 import { peacockVslsMementos } from './live-share/constants';
-import { peacockRemoteMementos } from './remote/constants';
 
 export interface IMementoLog {
   name: string;
@@ -55,11 +54,9 @@ export async function resetMementos() {
 
   // Global
   await ec.globalState.update(peacockMementos.favoritesVersion, undefined);
+
   await ec.globalState.update(peacockVslsMementos.vslsJoinColor, undefined);
   await ec.globalState.update(peacockVslsMementos.vslsShareColor, undefined);
-  await ec.globalState.update(peacockRemoteMementos.remoteContainersColor, undefined);
-  await ec.globalState.update(peacockRemoteMementos.remoteSshColor, undefined);
-  await ec.globalState.update(peacockRemoteMementos.remoteWslColor, undefined);
 
   // Workspace
   await ec.workspaceState.update(peacockMementos.peacockColor, undefined);
@@ -84,21 +81,6 @@ export function getMementos() {
     name: peacockVslsMementos.vslsShareColor,
     type: 'globalState',
     value: ec.globalState.get(peacockVslsMementos.vslsShareColor),
-  });
-  mementos.push({
-    name: peacockRemoteMementos.remoteContainersColor,
-    type: 'globalState',
-    value: ec.globalState.get(peacockRemoteMementos.remoteContainersColor),
-  });
-  mementos.push({
-    name: peacockRemoteMementos.remoteSshColor,
-    type: 'globalState',
-    value: ec.globalState.get(peacockRemoteMementos.remoteSshColor),
-  });
-  mementos.push({
-    name: peacockRemoteMementos.remoteWslColor,
-    type: 'globalState',
-    value: ec.globalState.get(peacockRemoteMementos.remoteWslColor),
   });
 
   // Workspace

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,3 +1,5 @@
+import { RemoteSettings } from '../remote/enums';
+
 export enum StandardSettings {
   ElementAdjustments = 'elementAdjustments',
   FavoriteColors = 'favoriteColors',
@@ -19,7 +21,7 @@ export enum AffectedSettings {
   TabActiveBorder = 'affectTabActiveBorder',
 }
 
-export type AllSettings = StandardSettings | AffectedSettings;
+export type AllSettings = StandardSettings | AffectedSettings | RemoteSettings;
 
 export enum Commands {
   resetColors = 'peacock.resetColors',

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,4 +1,5 @@
 import { RemoteSettings } from '../remote/enums';
+import { LiveShareSettings } from '../live-share/enums';
 
 export enum StandardSettings {
   ElementAdjustments = 'elementAdjustments',
@@ -21,7 +22,7 @@ export enum AffectedSettings {
   TabActiveBorder = 'affectTabActiveBorder',
 }
 
-export type AllSettings = StandardSettings | AffectedSettings | RemoteSettings;
+export type AllSettings = StandardSettings | AffectedSettings | RemoteSettings | LiveShareSettings;
 
 export enum Commands {
   resetColors = 'peacock.resetColors',

--- a/src/remote/constants.ts
+++ b/src/remote/constants.ts
@@ -1,7 +1,0 @@
-import { extensionShortName } from '../models';
-
-export const peacockRemoteMementos = {
-  remoteWslColor: `${extensionShortName}.remote.wsl.color`,
-  remoteSshColor: `${extensionShortName}.remote.ssh.color`,
-  remoteContainersColor: `${extensionShortName}.remote.containers.color`,
-};

--- a/src/remote/enums.ts
+++ b/src/remote/enums.ts
@@ -9,3 +9,9 @@ export enum RemoteNames {
   sshRemote = 'ssh-remote',
   devContainer = 'dev-container',
 }
+
+export enum RemoteSettings {
+  RemoteContainersColor = 'remoteContainersColor',
+  RemoteSshColor = 'remoteSshColor',
+  RemoteWslColor = 'remoteWslColor',
+}

--- a/src/remote/integration.ts
+++ b/src/remote/integration.ts
@@ -1,45 +1,41 @@
 import * as vscode from 'vscode';
 
-import { peacockRemoteMementos } from './constants';
 import { changeColor } from '../color-library';
 import { registerRemoteIntegrationCommands } from './remote-commands';
-import { RemoteNames } from './enums';
+import { RemoteNames, RemoteSettings } from './enums';
 import { getPeacockColorWorkspaceMemento } from '../mementos';
 import { State } from '../models';
 import { notify } from '../notification';
+import { getRemoteColor } from '../configuration';
 
-export function remoteMementoName(): string | undefined {
-  let mementoName = undefined;
+function getRemoteSettingName() {
+  let setting = undefined;
   switch (vscode.env.remoteName) {
     case RemoteNames.wsl:
-      mementoName = peacockRemoteMementos.remoteWslColor;
+      setting = RemoteSettings.RemoteWslColor;
       break;
     case RemoteNames.sshRemote:
-      mementoName = peacockRemoteMementos.remoteSshColor;
+      setting = RemoteSettings.RemoteSshColor;
       break;
     case RemoteNames.devContainer:
-      mementoName = peacockRemoteMementos.remoteContainersColor;
+      setting = RemoteSettings.RemoteContainersColor;
       break;
   }
-  return mementoName;
+  return setting;
 }
 
 async function setRemoteWorkspaceColors() {
-  const remoteColorSetting = getRemoteColor();
-  if (!remoteColorSetting) {
+  let setting = getRemoteSettingName();
+
+  if (!setting) {
+    return;
+  }
+  const remoteColor = getRemoteColor(setting);
+  if (!remoteColor) {
     return;
   }
 
-  await changeColor(remoteColorSetting, false);
-}
-
-export function getRemoteColor() {
-  let mementoName = remoteMementoName();
-
-  if (!mementoName) {
-    return;
-  }
-  return State.extensionContext.globalState.get<string>(mementoName);
+  await changeColor(remoteColor, false);
 }
 
 function remoteExtensionsInstalled(): boolean {

--- a/src/remote/remote-commands.ts
+++ b/src/remote/remote-commands.ts
@@ -2,24 +2,22 @@ import { commands, ExtensionContext } from 'vscode';
 
 import { promptForFavoriteColor } from '../inputs';
 import { isValidColorInput, changeColor } from '../color-library';
-import { peacockRemoteMementos } from './constants';
-import { RemoteCommands, RemoteNames } from './enums';
+import { RemoteCommands, RemoteNames, RemoteSettings } from './enums';
 import { revertRemoteWorkspaceColors, refreshRemoteColor } from './integration';
-import { getCurrentColorBeforeAdjustments } from '../configuration';
-import { saveGlobalMemento } from '../mementos';
+import { getCurrentColorBeforeAdjustments, updateRemoteColor } from '../configuration';
 import { State } from '../models';
 
 // Returning the extension context is used by the tests, so that they have a way to access it
-async function changeColorForMemento(
-  mementoName: string,
+async function changeColorForRemote(
+  settingName: RemoteSettings,
   remoteName: string,
 ): Promise<ExtensionContext> {
   const startingColor = getCurrentColorBeforeAdjustments();
   const input = await promptForFavoriteColor();
 
   if (isValidColorInput(input)) {
-    if (mementoName) {
-      await saveGlobalMemento(mementoName, input);
+    if (settingName) {
+      await updateRemoteColor(settingName, input);
     }
   }
   const isRefreshed = await refreshRemoteColor(remoteName);
@@ -37,18 +35,15 @@ async function changeColorForMemento(
 }
 
 async function changeRemoteContainersColor(): Promise<ExtensionContext> {
-  return changeColorForMemento(
-    peacockRemoteMementos.remoteContainersColor,
-    RemoteNames.devContainer,
-  );
+  return changeColorForRemote(RemoteSettings.RemoteContainersColor, RemoteNames.devContainer);
 }
 
 async function changeRemoteWslColor(): Promise<ExtensionContext> {
-  return changeColorForMemento(peacockRemoteMementos.remoteWslColor, RemoteNames.wsl);
+  return changeColorForRemote(RemoteSettings.RemoteWslColor, RemoteNames.wsl);
 }
 
 async function changeRemoteSshColor(): Promise<ExtensionContext> {
-  return changeColorForMemento(peacockRemoteMementos.remoteSshColor, RemoteNames.sshRemote);
+  return changeColorForRemote(RemoteSettings.RemoteSshColor, RemoteNames.sshRemote);
 }
 
 export function registerRemoteIntegrationCommands() {
@@ -61,7 +56,7 @@ export function registerRemoteIntegrationCommands() {
 }
 
 export async function resetRemotePreviousColors() {
-  await saveGlobalMemento(peacockRemoteMementos.remoteContainersColor, null);
-  await saveGlobalMemento(peacockRemoteMementos.remoteSshColor, null);
-  await saveGlobalMemento(peacockRemoteMementos.remoteWslColor, null);
+  await updateRemoteColor(RemoteSettings.RemoteContainersColor, '');
+  await updateRemoteColor(RemoteSettings.RemoteSshColor, '');
+  await updateRemoteColor(RemoteSettings.RemoteWslColor, '');
 }

--- a/src/test/suite/current-color.test.ts
+++ b/src/test/suite/current-color.test.ts
@@ -6,7 +6,7 @@ import { executeCommand } from './lib/constants';
 import { getCurrentColorBeforeAdjustments } from '../../configuration';
 import sinon = require('sinon');
 
-suite.only('Current Color Tests', () => {
+suite('Current Color Tests', () => {
   let originalValues = <IPeacockSettings>{};
 
   suiteSetup(async () => await setupTestSuite(originalValues));

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -12,26 +12,26 @@ export function run(): Promise<void> {
     timeout: 7500, // longer timeout, in case
     useColors: true, // colored output from test results
     //----------------------------------------
-    reporter: "mocha-multi-reporters",
+    reporter: 'mocha-multi-reporters',
     reporterOptions: {
-      reporterEnabled: "spec, xunit",
+      reporterEnabled: 'spec, xunit',
       xunitReporterOptions: {
-        output: path.join(__dirname, "..", "..", "test-results.xml")
-      }
-    }
+        output: path.join(__dirname, '..', '..', 'test-results.xml'),
+      },
+    },
   });
   mocha.useColors(true);
 
   const testsRoot = path.resolve(__dirname, '..');
 
   return new Promise((c, e) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err: any, files: any) => {
       if (err) {
         return e(err);
       }
 
       // Add files to the test suite
-      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+      files.forEach((f: any) => mocha.addFile(path.resolve(testsRoot, f)));
 
       try {
         // Run the mocha test

--- a/src/test/suite/remote.test.ts
+++ b/src/test/suite/remote.test.ts
@@ -7,9 +7,8 @@ import { setupTestSuite, setupTest, teardownTestSuite } from './lib/setup-teardo
 import { isValidColorInput } from '../../color-library';
 import { executeCommand } from './lib/constants';
 
-import { getPeacockWorkspaceConfig } from '../../configuration';
-import { peacockRemoteMementos } from '../../remote/constants';
-import { RemoteCommands, RemoteNames } from '../../remote/enums';
+import { getPeacockWorkspaceConfig, readConfiguration } from '../../configuration';
+import { RemoteCommands, RemoteNames, RemoteSettings } from '../../remote/enums';
 
 suite('Remote Integration', () => {
   let originalValues = <IPeacockSettings>{};
@@ -40,10 +39,7 @@ suite('Remote Integration', () => {
   test('can set color setting for Remote WSL', async () => {
     await executeCommand<vscode.ExtensionContext>(RemoteCommands.changeColorOfRemoteWsl);
 
-    const settingValue = extensionContext!.globalState.get<string>(
-      peacockRemoteMementos.remoteWslColor,
-      '',
-    );
+    const settingValue = readConfiguration<string>(RemoteSettings.RemoteWslColor, '');
 
     console.log('settingValue');
     console.log(settingValue);
@@ -53,10 +49,7 @@ suite('Remote Integration', () => {
   test('can set color setting for Remote SSH', async () => {
     await executeCommand<vscode.ExtensionContext>(RemoteCommands.changeColorOfRemoteSsh);
 
-    const settingValue = extensionContext!.globalState.get<string>(
-      peacockRemoteMementos.remoteSshColor,
-      '',
-    );
+    const settingValue = readConfiguration<string>(RemoteSettings.RemoteSshColor, '');
 
     assert(isValidColorInput(settingValue));
     assert(settingValue === azureBlue);
@@ -65,10 +58,7 @@ suite('Remote Integration', () => {
   test('can set color setting for Remote Containers', async () => {
     await executeCommand<vscode.ExtensionContext>(RemoteCommands.changeColorOfRemoteContainers);
 
-    const settingValue = extensionContext!.globalState.get<string>(
-      peacockRemoteMementos.remoteContainersColor,
-      '',
-    );
+    const settingValue = readConfiguration<string>(RemoteSettings.RemoteContainersColor, '');
 
     assert(isValidColorInput(settingValue));
     assert(settingValue === azureBlue);


### PR DESCRIPTION
fixes #193

Refactoring

- Removed remote colors and live share colors from mementos and instead created user settings for these. Mementos are best for values the user cant see, while settings make it easier for the user to see them and modify them directly. This feels right for these colors.
  - `peacock.remoteContainersColor` - Peacock color when in a remote with a container.
  - `peacock.remoteSshColor` - Peacock color when using remote with ssh.
  - `peacock.remoteWslColor` - Peacock color when using remote with WSL
  - `peacock.vslsShareColor` - Peacock color for Live Share Hosting
  - `peacock.vslsJoinColor` - Peacock color for Live Share Joining
