### PR TITLE
Fixes #216: do not apply a remote color when a remote workspace has a custom color set

### DIFF
--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -39,13 +39,13 @@ export async function promptForFavoriteColorName(color: string) {
   return inputName || '';
 }
 
-export async function promptForFavoriteColor() {
+export async function promptForFavoriteColor(isPrimaryEnvironment: boolean = false) {
   const { menu, values: favoriteColors } = getFavoriteColors();
   let selection = '';
   const startingColor = getCurrentColorBeforeAdjustments();
   const options = {
     placeHolder: 'Pick a favorite color',
-    onDidSelectItem: tryColorWithPeacock(),
+    onDidSelectItem: tryColorWithPeacock(isPrimaryEnvironment),
   };
   if (favoriteColors && favoriteColors.length) {
     selection = (await vscode.window.showQuickPick(menu, options)) || '';
@@ -57,7 +57,7 @@ export async function promptForFavoriteColor() {
 
   if (isValidColorInput(startingColor)) {
     // when there is no selection and startingColor, revert to starting color
-    await changeColor(startingColor);
+    await changeColor(startingColor, isPrimaryEnvironment);
   } else {
     // if no color was previously set, reset the current color to `null`
     await setPeacockColorCustomizations(null);
@@ -71,9 +71,9 @@ export function parseFavoriteColorValue(text: string) {
   return text.substring(text.indexOf(sep) + sep.length + 1);
 }
 
-function tryColorWithPeacock() {
+function tryColorWithPeacock(isPrimaryEnvironement: boolean) {
   return async (item: string) => {
     const color = parseFavoriteColorValue(item as string);
-    return await changeColor(color);
+    return await changeColor(color, isPrimaryEnvironement);
   };
 }

--- a/src/remote/integration.ts
+++ b/src/remote/integration.ts
@@ -59,7 +59,10 @@ export async function addRemoteIntegration(context: vscode.ExtensionContext) {
     revertRemoteWorkspaceColors();
     return;
   }
-  setRemoteWorkspaceColors();
+  // don't overwrite an already defined custom color
+  if (!getPeacockColorWorkspaceMemento()) {
+    setRemoteWorkspaceColors();
+  }
 }
 
 export async function refreshRemoteColor(remote: string): Promise<boolean> {
@@ -70,7 +73,13 @@ export async function refreshRemoteColor(remote: string): Promise<boolean> {
     );
     return false;
   }
-
+  if (getPeacockColorWorkspaceMemento()) {
+    notify(
+      `The current workspace already uses a peacock color, the selected color will not be applied for this workspace.`,
+      true,
+    );
+    return false;
+  }
   await setRemoteWorkspaceColors();
   return true;
 }


### PR DESCRIPTION
Fix for #216