### PR TITLE
3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the code will be documented in this file.
 
+## 3.0.1
+
+Fixes
+
+- When settings.json doesn't exist, and surprise me on startup is true, Peacock was writing an empty file for settings.json. It shouldn't. So it now checks if it is trying to write an empty object AND there is no workbench.colorCustomizations section already, it won't write.
+
 ## 3.0.0
 
 Migration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-peacock",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -11,9 +11,10 @@ import {
   AffectedSettings,
   starterSetOfFavorites,
   getExtensionVersion,
+  isObjectEmpty,
 } from '../models';
 import { Logger } from '../logging';
-import { getFavoriteColors } from './read-configuration';
+import { getFavoriteColors, getColorCustomizationConfigFromWorkspace } from './read-configuration';
 import { notify } from '../notification';
 import { LiveShareSettings } from '../live-share';
 
@@ -30,6 +31,22 @@ export async function updateGlobalConfiguration<T>(setting: AllSettings, value?:
 }
 
 export async function updateWorkspaceConfiguration(colorCustomizations: {} | undefined) {
+  if (isObjectEmpty(colorCustomizations)) {
+    // We are receiving an empty object, so let's make it undefined.
+    // This means we can skip writing the workbench.colorCustomizations section
+    // if one doesnt already exist.
+    colorCustomizations = undefined;
+  }
+
+  if (!colorCustomizations) {
+    // If it is undefined and the file doesn't exist, let's just get out.
+    // Otherwise, we risk writing an empty file, which is annoying.
+    const existingWorkspace = getColorCustomizationConfigFromWorkspace();
+    if (isObjectEmpty(existingWorkspace)) {
+      return;
+    }
+  }
+
   Logger.info(
     `${extensionShortName}: Updating the workspace with the following color customizations`,
   );

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -19,4 +19,5 @@ export const peacockMementos = {
 
 export const timeout = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
 
-export const isObjectEmpty = (o: {}) => !Object.keys(o).length;
+export const isObjectEmpty = (o: {} | undefined) =>
+  typeof o === 'object' && Object.keys(o).length === 0;


### PR DESCRIPTION
Fixes #233

When settings.json doesn't exist, and surprise me on startup is true, Peacock was writing an empty file for settings.json. It shouldn't. So it now checks if it is trying to write an empty object AND there is no workbench.colorCustomizations section already, it won't write.