### PR TITLE
Migrate/only check workspace

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -12,12 +12,22 @@ meta:
 
 All notable changes to the code will be documented in this file.
 
-## 3.1.2
+## 3.1.4
+
+Fixes
+
+- Migration occurs when colors are in user settings but not in workspace.
+  - During migration, Peacock is checking if the current workspace has a color set in the old style. This could be a `activityBar.background`, `titleBar.background`, or `statusBar.background`. PeacockVS Code's API merges default settings, users settings and workspace settings. Therefore, this migration logic was sometimes getting a migrating, and it should not. Peacock should only migrate to the new `peacock.color settings (which make sit much easier to determine what the color is definitively) if there is a color in the workspace settings. The fix for this was to write logic that gets the workspace colors only. This is done in a new function named`getWorkspaceColorIfExists`.
 
 Changes
 
 - Writing less but clearer messages to the output channel for Peacock
 - Added more migration and FAQ to the guide/docs
+- Refactored migration logic to a single file.
+- Function refactorings
+  - `getWorkspaceColorIfExists` --> get (and calculate for adjustments) a single color from the workspace settings if one exists. Ideal for migration when peacock.color did not exist in < v3.
+  - `getOriginalColor` --> if a non color is passed in, then pass the same thing back out. This protects against having a undefined or empty string passed in and #000 being passed out.
+  - `getElementColors` --> allows both `vscode.workspaceConfiguration` type AND `ISettingsIndexer`, since sometimes we have one or the other
 
 ## 3.1.1
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -17,6 +17,7 @@ All notable changes to the code will be documented in this file.
 Fixes
 
 - Migration occurs when colors are in user settings but not in workspace.
+  - Fixes [263](https://github.com/johnpapa/vscode-peacock/issues/263)
   - During migration, Peacock is checking if the current workspace has a color set in the old style. This could be a `activityBar.background`, `titleBar.background`, or `statusBar.background`. PeacockVS Code's API merges default settings, users settings and workspace settings. Therefore, this migration logic was sometimes getting a migrating, and it should not. Peacock should only migrate to the new `peacock.color settings (which make sit much easier to determine what the color is definitively) if there is a color in the workspace settings. The fix for this was to write logic that gets the workspace colors only. This is done in a new function named`getWorkspaceColorIfExists`.
 
 Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "3.1.2",
+  "version": "3.1.4",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,13 +31,13 @@ import {
   inspectColor,
   getCurrentColorBeforeAdjustments,
   getFavoriteColors,
-  getPeacockColor,
 } from './configuration';
 import { applyColor, updateColorSetting } from './apply-color';
 import { Logger } from './logging';
 import { addLiveShareIntegration } from './live-share';
 import { addRemoteIntegration } from './remote';
 import { saveFavoritesVersionGlobalMemento, getMementos } from './mementos';
+import { migrateFromMementoToSettingsAsNeeded } from './migration';
 
 const { commands, workspace } = vscode;
 
@@ -72,57 +72,6 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   addSubscriptions(); // add these AFTER applying initial config
-}
-
-async function migrateFromMementoToSettingsAsNeeded() {
-  /**
-   * Version >2.5 of Peacock did not store the peacock color.
-   * Version 2.5 of Peacock stored the peacock color in a memento.
-   * Version 3 of Peacock stores the color in the settings.
-   * If peacock.color does not exist and we find either memento or a deried color,
-   * remove the memento, and write the apply the color to the settings.
-   *
-   * @deprecated since version 3.0.
-   * Will be deleted in version 4.0 and once v3.0 users have migrated
-   */
-
-  // If peacock.color exists, get out. Nothing to migrate.
-  const peacockColorExists = !!getPeacockColor();
-  if (peacockColorExists) {
-    Logger.info('Migration: Nothing to migrate, peacock.color exists.');
-    return;
-  }
-
-  // Check for the v2.5 memento
-  const peacockColorMementoName = `${extensionShortName}.peacockColor`;
-  const peacockColorMemento = State.extensionContext.workspaceState.get<string>(
-    peacockColorMementoName,
-  );
-
-  let derivedColor = undefined;
-  // The v2 memento is gone, so no need to migrate.
-  if (peacockColorMemento) {
-    Logger.info('Migration: Migrating from peacock memento to peacock.color setting.');
-    // Remove the v2 memento (it's ok if it doesnt exist)
-    await State.extensionContext.workspaceState.update(peacockColorMementoName, undefined);
-  } else {
-    /**
-     * If there is no memento, check if there is a
-     * color set in the 'old style' w/o the setting peacock.color.
-     * If there is, then let's grab it and set it.
-     */
-    derivedColor = getCurrentColorBeforeAdjustments() || undefined;
-  }
-
-  // Migrate the color that was in the v2 memento
-  // or the derived color to the v3 workspace setting
-  const color = peacockColorMemento || derivedColor;
-
-  if (color) {
-    // If we found something to migrate then do it
-    Logger.info(`Migration: Applying color ${color}.`);
-    await updateColorSetting(color);
-  }
 }
 
 function addSubscriptions() {

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,5 +1,8 @@
 import { State, extensionShortName } from './models';
-import { getCurrentColorBeforeAdjustments, getPeacockColor } from './configuration';
+import {
+  getPeacockColor,
+  getWorkspaceColorIfExists,
+} from './configuration';
 import { updateColorSetting } from './apply-color';
 import { Logger } from './logging';
 
@@ -33,12 +36,13 @@ export async function migrateFromMementoToSettingsAsNeeded() {
     await State.extensionContext.workspaceState.update(peacockColorMementoName, undefined);
   } else {
     /**
-     * If there is no memento, check if there is a
-     * color set in the 'old style' w/o the setting peacock.color.
+     * There is no memento, so let's check if there is a
+     * color set in the 'old style' w/o the setting peacock.color
+     * and let's only check in the workspace settings.json.
      * If there is, then let's grab it and set it.
      */
-    colorConfig = getColorCustomizationConfigFromWorkspace();
-    derivedColor = getCurrentColorBeforeAdjustments() || undefined;
+
+    derivedColor = getWorkspaceColorIfExists() || undefined;
   }
   // Migrate the color that was in the v2 memento
   // or the derived color to the v3 workspace setting

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,0 +1,51 @@
+import { State, extensionShortName } from './models';
+import { getCurrentColorBeforeAdjustments, getPeacockColor } from './configuration';
+import { updateColorSetting } from './apply-color';
+import { Logger } from './logging';
+
+export async function migrateFromMementoToSettingsAsNeeded() {
+  /**
+   * Version >2.5 of Peacock did not store the peacock color.
+   * Version 2.5 of Peacock stored the peacock color in a memento.
+   * Version 3 of Peacock stores the color in the settings.
+   * If peacock.color does not exist and we find either memento or a deried color,
+   * remove the memento, and write the apply the color to the settings.
+   *
+   * @deprecated since version 3.0.
+   * Will be deleted in version 4.0 and once v3.0 users have migrated
+   */
+  // If peacock.color exists, get out. Nothing to migrate.
+  const peacockColorExists = !!getPeacockColor();
+  if (peacockColorExists) {
+    Logger.info('Migration: Nothing to migrate, peacock.color exists.');
+    return;
+  }
+  // Check for the v2.5 memento
+  const peacockColorMementoName = `${extensionShortName}.peacockColor`;
+  const peacockColorMemento = State.extensionContext.workspaceState.get<string>(
+    peacockColorMementoName,
+  );
+  let derivedColor = undefined;
+  // The v2 memento is gone, so no need to migrate.
+  if (peacockColorMemento) {
+    Logger.info('Migration: Migrating from peacock memento to peacock.color setting.');
+    // Remove the v2 memento (it's ok if it doesnt exist)
+    await State.extensionContext.workspaceState.update(peacockColorMementoName, undefined);
+  } else {
+    /**
+     * If there is no memento, check if there is a
+     * color set in the 'old style' w/o the setting peacock.color.
+     * If there is, then let's grab it and set it.
+     */
+    colorConfig = getColorCustomizationConfigFromWorkspace();
+    derivedColor = getCurrentColorBeforeAdjustments() || undefined;
+  }
+  // Migrate the color that was in the v2 memento
+  // or the derived color to the v3 workspace setting
+  const color = peacockColorMemento || derivedColor;
+  if (color) {
+    // If we found something to migrate then do it
+    Logger.info(`Migration: Applying color ${color}.`);
+    await updateColorSetting(color);
+  }
+}

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,8 +1,5 @@
 import { State, extensionShortName } from './models';
-import {
-  getPeacockColor,
-  getWorkspaceColorIfExists,
-} from './configuration';
+import { getPeacockColor, getWorkspaceColorIfExists } from './configuration';
 import { updateColorSetting } from './apply-color';
 import { Logger } from './logging';
 
@@ -42,6 +39,7 @@ export async function migrateFromMementoToSettingsAsNeeded() {
      * If there is, then let's grab it and set it.
      */
 
+    // NOTE: If we ever remove this migration logic entirely, check if this function `getWorkspaceColorIfExists` is still be using or not, too.
     derivedColor = getWorkspaceColorIfExists() || undefined;
   }
   // Migrate the color that was in the v2 memento


### PR DESCRIPTION
## 3.1.4

Fixes

- Migration occurs when colors are in user settings but not in workspace. (fixes #263)
  - During migration, Peacock is checking if the current workspace has a color set in the old style. This could be a `activityBar.background`, `titleBar.background`, or `statusBar.background`. PeacockVS Code's API merges default settings, users settings and workspace settings. Therefore, this migration logic was sometimes getting a migrating, and it should not. Peacock should only migrate to the new `peacock.color settings (which make sit much easier to determine what the color is definitively) if there is a color in the workspace settings. The fix for this was to write logic that gets the workspace colors only. This is done in a new function named`getWorkspaceColorIfExists`.

Changes

- Writing less but clearer messages to the output channel for Peacock
- Added more migration and FAQ to the guide/docs
- Refactored migration logic to a single file.
- Function refactorings
  - `getWorkspaceColorIfExists` --> get (and calculate for adjustments) a single color from the workspace settings if one exists. Ideal for migration when peacock.color did not exist in < v3.
  - `getOriginalColor` --> if a non color is passed in, then pass the same thing back out. This protects against having a undefined or empty string passed in and #000 being passed out.
  - `getElementColors` --> allows both `vscode.workspaceConfiguration` type AND `ISettingsIndexer`, since sometimes we have one or the other
