### PR TITLE
added activityBar.activeBorder color. It uses the acent color from the badge color.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -28,3 +28,4 @@ Verify that the following are valid
 - [ ] Dead code removed
 - [ ] Unnecessary comments removed
 - [ ] Images updated (if applicable)
+- [ ] Version updated everywhere

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,10 +9,10 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "workbench.colorCustomizations": {
-    "activityBar.background": "#174a8e",
+    "activityBar.background": "#103362",
     "activityBar.foreground": "#e7e7e7",
     "activityBar.inactiveForeground": "#e7e7e799",
-    "activityBarBadge.background": "#e03f84",
+    "activityBarBadge.background": "#c01f64",
     "activityBarBadge.foreground": "#e7e7e7",
     "titleBar.activeBackground": "#103362",
     "titleBar.inactiveBackground": "#10336299",
@@ -20,11 +20,7 @@
     "titleBar.inactiveForeground": "#e7e7e799",
     "statusBar.background": "#103362",
     "statusBarItem.hoverBackground": "#174a8e",
-    "statusBar.foreground": "#e7e7e7",
-    "panel.border": "#174a8e",
-    "sideBar.border": "#174a8e",
-    "editorGroup.border": "#174a8e",
-    "tab.activeBorder": "#174a8e"
+    "statusBar.foreground": "#e7e7e7"
   },
   "peacock.color": "103362"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,5 +10,5 @@ features:
     details: Color your Visual Studio Code editor uniquely when you are using the remote integration features.
   - title: Live Share
     details: Color your Visual Studio Code editor uniquely when you are in a Live Share session as a Guest or a Host
-footer: MIT Licensed | Copyright © 2019-present John Papa | Current Version 3.1.6
+footer: MIT Licensed | Copyright © 2019-present John Papa | Current Version 3.2.0
 ---

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -12,6 +12,12 @@ meta:
 
 All notable changes to the code will be documented in this file.
 
+## 3.2.0
+
+Features
+
+- October 2019 release of VS Code added `activityBar.activeBorder` color. It was using a color that often clashed, so it now uses the accent color from the badge color. this color setting is available in October 2019 release of vs code as shown here. https://code.visualstudio.com/updates/v1_40
+
 ## 3.1.6
 
 Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-peacock",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -248,11 +248,7 @@ export function getElementAdjustment(elementName: string): ColorAdjustment {
   return elementAdjustments[elementName];
 }
 
-export function getElementStyle(
-  backgroundHex: string,
-  elementName?: string,
-  includeBadgeStyles = false,
-): IElementStyle {
+export function getElementStyle(backgroundHex: string, elementName?: string): IElementStyle {
   let styleHex = backgroundHex;
 
   if (elementName) {
@@ -270,10 +266,8 @@ export function getElementStyle(
     inactiveForegroundHex: getInactiveForegroundColorHex(styleHex),
   } as IElementStyle;
 
-  if (includeBadgeStyles) {
-    style.badgeBackgroundHex = getBadgeBackgroundColorHex(styleHex);
-    style.badgeForegroundHex = getForegroundColorHex(style.badgeBackgroundHex);
-  }
+  style.badgeBackgroundHex = getBadgeBackgroundColorHex(styleHex);
+  style.badgeForegroundHex = getForegroundColorHex(style.badgeBackgroundHex);
 
   return style;
 }
@@ -320,8 +314,10 @@ function collectActivityBarSettings(
   const activityBarSettings = {} as ISettingsIndexer;
 
   if (isAffectedSettingSelected(AffectedSettings.ActivityBar)) {
-    const activityBarStyle = getElementStyle(backgroundHex, ElementNames.activityBar, true);
+    const activityBarStyle = getElementStyle(backgroundHex, ElementNames.activityBar);
     activityBarSettings[ColorSettings.activityBar_background] = activityBarStyle.backgroundHex;
+    activityBarSettings[ColorSettings.activityBar_activeBorder] =
+      activityBarStyle.badgeBackgroundHex;
 
     if (!keepForegroundColor) {
       activityBarSettings[ColorSettings.activityBar_foreground] = activityBarStyle.foregroundHex;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -54,6 +54,7 @@ export enum ColorSettings {
   activityBar_background = 'activityBar.background',
   activityBar_foreground = 'activityBar.foreground',
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',
+  activityBar_activeBorder = 'activityBar.activeBorder',
   activityBar_badgeBackground = 'activityBarBadge.background',
   activityBar_badgeForeground = 'activityBarBadge.foreground',
   statusBar_background = 'statusBar.background',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -131,6 +131,7 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.activityBar_background]);
       assert.ok(!config[ColorSettings.activityBar_foreground]);
       assert.ok(!config[ColorSettings.activityBar_inactiveForeground]);
+      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
       assert.ok(!config[ColorSettings.statusBar_foreground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.accentBorders_panelBorder]);
@@ -281,6 +282,7 @@ async function testsDoesNotSetColorCustomizationsForAffectedElements() {
   assert.ok(!config[ColorSettings.activityBar_inactiveForeground]);
   assert.ok(!config[ColorSettings.statusBar_foreground]);
   assert.ok(!config[ColorSettings.statusBar_background]);
+  assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
   // reset
   await updateAffectedElements(allAffectedElements);
@@ -316,8 +318,9 @@ async function testsSetsColorCustomizationsForAffectedElements() {
     ),
   );
 
-  const activityBarStyle = getElementStyle(peacockGreen, 'activityBar', true);
+  const activityBarStyle = getElementStyle(peacockGreen, 'activityBar');
   assert.equal(activityBarStyle.backgroundHex, config[ColorSettings.activityBar_background]);
+  assert.equal(activityBarStyle.badgeBackgroundHex, config[ColorSettings.activityBar_activeBorder]);
 
   assert.ok(
     shouldKeepColorTest(

--- a/src/test/suite/built-in-colors.test.ts
+++ b/src/test/suite/built-in-colors.test.ts
@@ -85,6 +85,7 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.titleBar_activeBackground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
+      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
       await removeExtraSetting(extraSettingName);
     });
@@ -95,6 +96,7 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.titleBar_activeBackground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
+      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
     });
 
     test('removes peacockColor', async () => {

--- a/testworkspace/.vscode/settings.json
+++ b/testworkspace/.vscode/settings.json
@@ -1,19 +1,20 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "peacock.color": "#00b3e6",
+  "peacock.color": "#215732",
   "workbench.colorCustomizations": {
-    "activityBar.background": "#1accff",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#df00ad",
+    "activityBar.background": "#2f7c47",
+    "activityBar.activeBorder": "#422c74",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#422c74",
     "activityBarBadge.foreground": "#e7e7e7",
-    "titleBar.activeBackground": "#00b3e6",
-    "titleBar.inactiveBackground": "#00b3e699",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveForeground": "#15202b99",
-    "statusBar.background": "#00b3e6",
-    "statusBarItem.hoverBackground": "#008bb3",
-    "statusBar.foreground": "#15202b"
+    "titleBar.activeBackground": "#215732",
+    "titleBar.inactiveBackground": "#21573299",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveForeground": "#e7e7e799",
+    "statusBar.background": "#215732",
+    "statusBarItem.hoverBackground": "#2f7c47",
+    "statusBar.foreground": "#e7e7e7"
   },
   "peacock.remoteColor": ""
 }


### PR DESCRIPTION
# activityBar.activeBorder

## Purpose

added activityBar.activeBorder color. It uses the acent color from the badge color.

this color setting is availble in October 2019 release of vs code as shown here. https://code.visualstudio.com/updates/v1_40

## Checklist of changes included

- [x] CHANGELOG updated
- [x] README updated
- [x] Tests updated/added
- [x] Prettier formatting
- [x] console.log removed
- [x] Dead code removed
- [x] Unnecessary comments removed
- [ ] Images updated (if applicable)
- [x] Version updated everywhere

## Future

Readme could be updated with images for the new `activityBar.activeBorder`.