### PR TITLE
Added command for showing help on missing commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "*"
   ],
   "extensionKind": [
-    "ui", 
+    "ui",
     "workspace"
   ],
   "main": "./dist/extension",
@@ -40,6 +40,11 @@
       {
         "command": "peacock.docs",
         "title": "Open the Documentation",
+        "category": "Peacock"
+      },
+      {
+        "command": "peacock.missingCommands",
+        "title": "Why I am not seeing other Options ?",
         "category": "Peacock"
       },
       {
@@ -122,6 +127,10 @@
       "commandPalette": [
         {
           "command": "peacock.docs"
+        },
+        {
+          "command": "peacock.missingCommands",
+          "when": "workspaceFolderCount == 0"
         },
         {
           "command": "peacock.changeColorOfLiveShareHost",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,6 +36,11 @@ export async function showDocumentationHandler() {
   return State.extensionContext;
 }
 
+export async function showMissingCommandsMessageHandler() {
+  await vscode.window.showInformationMessage(`Peacock only works if a workspace is open`);
+  return State.extensionContext;
+}
+
 export async function resetWorkspaceColorsHandler() {
   await resetLiveSharePreviousColors();
   await updatePeacockColor(undefined);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import {
   showAndCopyCurrentColorHandler,
   removeAllPeacockColorsHandler,
   showDocumentationHandler,
+  showMissingCommandsMessageHandler
 } from './commands';
 import {
   checkIfPeacockSettingsChanged,
@@ -108,6 +109,7 @@ function applyPeacock(): (e: vscode.ConfigurationChangeEvent) => any {
 
 function registerCommands() {
   commands.registerCommand(Commands.showDocumentation, showDocumentationHandler);
+  commands.registerCommand(Commands.showMissingCommands, showMissingCommandsMessageHandler);
   commands.registerCommand(Commands.resetWorkspaceColors, resetWorkspaceColorsHandler);
   commands.registerCommand(Commands.removeAllColors, removeAllPeacockColorsHandler);
   commands.registerCommand(Commands.saveColorToFavorites, saveColorToFavoritesHandler);

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -27,6 +27,7 @@ export type AllSettings = StandardSettings | AffectedSettings | LiveShareSetting
 
 export enum Commands {
   showDocumentation = 'peacock.docs',
+  showMissingCommands = 'peacock.missingCommands',
   resetWorkspaceColors = 'peacock.resetWorkspaceColors',
   removeAllColors = 'peacock.removeAllColors',
   saveColorToFavorites = 'peacock.saveColorToFavorites',


### PR DESCRIPTION
By default if installed with out opening a workspace, no commands will be displayed. Only command to open the documentation is shown. 

This feature will add another command "peacock.missingCommands" which will show a information to the developer on the requirement for a workspace. 

This makes life easier :) 