### PR TITLE
Fixed a bug where workspace settings were written to implicitly.

### DIFF
--- a/src/apply-color.ts
+++ b/src/apply-color.ts
@@ -21,14 +21,14 @@ export async function unapplyColors() {
     return;
   }
 
-  // Overwite color customizations, without the peacock ones.
+  // Overwrite color customizations, without the peacock ones.
   // This preserves any extra ones someone might have.
   const colorCustomizationsWithPeacock = deletePeacocksColorCustomizations();
   await updateWorkspaceConfiguration(colorCustomizationsWithPeacock);
   updateStatusBar();
 }
 
-export async function applyColor(input: string) {
+export async function applyColor(input: string, updateWorkspaceConfig: boolean) {
   /**************************************************************
    * This is the heart of Peacock logic to apply the colors.
    *
@@ -60,7 +60,11 @@ export async function applyColor(input: string) {
     ...newColors,
   };
 
-  await updateWorkspaceConfiguration(colorCustomizations);
+  // Only update workspace config, when explicitly instructed.
+  if (updateWorkspaceConfig) {
+    await updateWorkspaceConfiguration(colorCustomizations);
+  }
+
   updateStatusBar();
 
   Logger.info(`${extensionShortName}: Peacock is now using ${color}`);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -63,7 +63,7 @@ export async function enterColorHandler(color?: string) {
   if (!isValidColorInput(input)) {
     throw new Error(`Invalid HEX or named color "${input}"`);
   }
-  await applyColor(input);
+  await applyColor(input, true);
   await updateColorSetting(input);
   return State.extensionContext;
 }
@@ -85,7 +85,7 @@ export async function changeColorToRandomHandler() {
     color = getRandomColorHex();
   }
 
-  await applyColor(color);
+  await applyColor(color, true);
   await updateColorSetting(color);
   return State.extensionContext;
 }
@@ -96,7 +96,7 @@ export async function addRecommendedFavoritesHandler() {
 }
 
 export async function changeColorToPeacockGreenHandler() {
-  await applyColor(peacockGreen);
+  await applyColor(peacockGreen, true);
   await updateColorSetting(peacockGreen);
   return State.extensionContext;
 }
@@ -109,13 +109,13 @@ export async function changeColorToFavoriteHandler() {
   if (isValidColorInput(favoriteColor)) {
     // We have a valid Favorite color,
     // apply it and write the new color to settings
-    await applyColor(favoriteColor);
+    await applyColor(favoriteColor, true);
     await updateColorSetting(favoriteColor);
   } else if (startingColor) {
     // No favorite was selected.
     // We need to re-apply the starting color
     // and write the new color to settings
-    await applyColor(startingColor);
+    await applyColor(startingColor, true);
     await updateColorSetting(startingColor);
   } else {
     // No favorite was selected. We had no color to start, either.
@@ -130,7 +130,7 @@ export async function darkenHandler() {
   if (color) {
     const darkenLightenPercentage = getDarkenLightenPercentage();
     const darkenedColor = getDarkenedColorHex(color, darkenLightenPercentage);
-    await applyColor(darkenedColor);
+    await applyColor(darkenedColor, true);
     await updateColorSetting(darkenedColor);
   }
   return State.extensionContext;
@@ -141,7 +141,7 @@ export async function lightenHandler() {
   if (color) {
     const darkenLightenPercentage = getDarkenLightenPercentage();
     const lightenedColor = getLightenedColorHex(color, darkenLightenPercentage);
-    await applyColor(lightenedColor);
+    await applyColor(lightenedColor, true);
     await updateColorSetting(lightenedColor);
   }
   return State.extensionContext;

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -80,7 +80,7 @@ export function getUserConfig() {
 
 export function getCurrentColorBeforeAdjustments() {
   /**
-   * Useful if we dont want the
+   * Useful if we don't want the
    *       peacock color but instead to calculate it from
    *       the current customized colors
    *

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -32,7 +32,7 @@ export async function updateWorkspaceConfiguration(colorCustomizations: {} | und
   if (isObjectEmpty(colorCustomizations)) {
     // We are receiving an empty object, so let's make it undefined.
     // This means we can skip writing the workbench.colorCustomizations section
-    // if one doesnt already exist.
+    // if one doesn't already exist.
     colorCustomizations = undefined;
   }
 
@@ -82,7 +82,7 @@ export async function updateLightForegroundColor(value: string) {
   return await updateGlobalConfiguration(StandardSettings.LightForegroundColor, value);
 }
 
-export async function updateDarkenLightenPrecentage(value: number) {
+export async function updateDarkenLightenPercentage(value: number) {
   return await updateGlobalConfiguration(StandardSettings.DarkenLightenPercentage, value);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ function applyPeacock(): (e: vscode.ConfigurationChangeEvent) => any {
       Logger.info(
         `${extensionShortName}: Configuration changed. Changing the color to most recently selected color: ${color}`,
       );
-      await applyColor(color);
+      await applyColor(color, true);
 
       // Only update the color in the workspace settings
       // if there was already a workspace setting

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -55,6 +55,6 @@ export function parseFavoriteColorValue(text: string) {
 async function tryColorWithPeacock() {
   return async (item: string) => {
     const color = parseFavoriteColorValue(item);
-    return await applyColor(color);
+    return await applyColor(color, true);
   };
 }

--- a/src/live-share/integration.ts
+++ b/src/live-share/integration.ts
@@ -31,7 +31,7 @@ async function setLiveShareSessionWorkspaceColors(isHost: boolean) {
     return;
   }
 
-  await applyColor(liveShareColorSetting);
+  await applyColor(liveShareColorSetting, true);
 }
 
 export async function refreshLiveShareSessionColor(isHostRole: boolean): Promise<boolean> {

--- a/src/live-share/liveshare-commands.ts
+++ b/src/live-share/liveshare-commands.ts
@@ -35,7 +35,7 @@ const changeColorOfLiveShareSessionFactory = (isHost: boolean) => {
       // if there was a color set prior to color picker,
       // set that color back
     } else {
-      await applyColor(startingColor);
+      await applyColor(startingColor, true);
     }
 
     return State.extensionContext;

--- a/src/remote/integration.ts
+++ b/src/remote/integration.ts
@@ -21,9 +21,9 @@ export async function addRemoteIntegration(context: vscode.ExtensionContext) {
 
   if (vscode.env.remoteName) {
     const remoteColor = getPeacockRemoteColor();
-    await applyColor(remoteColor);
+    await applyColor(remoteColor, false);
   } else {
     const peacockColor = getPeacockColor();
-    await applyColor(peacockColor);
+    await applyColor(peacockColor, false);
   }
 }

--- a/src/test/suite/editing-color-settings.test.ts
+++ b/src/test/suite/editing-color-settings.test.ts
@@ -41,7 +41,7 @@ suite('Manual Editing of Settings', () => {
           remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
           await updateRemoteColorInUserSettings(peacockGreen);
           await updateRemoteColorInWorkspace(azureBlue);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
         });
         teardown(() => {
           remoteNameStub.restore();
@@ -54,14 +54,14 @@ suite('Manual Editing of Settings', () => {
 
         test('user changes User Settings remoteColor to YELLOW, color should remain BLUE', async () => {
           await updateRemoteColorInUserSettings(yellow);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
           const appliedColor = getCurrentColorBeforeAdjustments();
           assert.equal(appliedColor, azureBlue);
         });
 
         test('user removes User Settings remoteColor, color should remain BLUE', async () => {
           await updateRemoteColorInUserSettings(undefined);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
           const appliedColor = getCurrentColorBeforeAdjustments();
           assert.equal(appliedColor, azureBlue);
         });
@@ -75,7 +75,7 @@ suite('Manual Editing of Settings', () => {
           remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
           await updateRemoteColorInUserSettings(peacockGreen);
           await updateRemoteColorInWorkspace(undefined);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
         });
         teardown(() => {
           remoteNameStub.restore();
@@ -88,14 +88,14 @@ suite('Manual Editing of Settings', () => {
 
         test('user changes User Settings remoteColor to YELLOW, color-customizations should be YELLOW', async () => {
           await updateRemoteColorInUserSettings(yellow);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
           const appliedColor = getCurrentColorBeforeAdjustments();
           assert.equal(appliedColor, yellow);
         });
 
         test('user removes User Settings remoteColor, color-customizations should be unapplied', async () => {
           await updateRemoteColorInUserSettings(undefined);
-          await applyColor(getPeacockRemoteColor());
+          await applyColor(getPeacockRemoteColor(), true);
           const appliedColor = getCurrentColorBeforeAdjustments();
           assert.ok(!appliedColor);
         });
@@ -107,7 +107,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
         await updateLocalColorInUserSettings(undefined);
         await updateLocalColorInWorkspace(azureBlue);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -120,14 +120,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color-customizations should be BLUE', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });
 
       test('user removes Workspace Settings color, color-customizations should be unapplied', async () => {
         await updateLocalColorInWorkspace(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.ok(!appliedColor);
       });
@@ -138,7 +138,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
         await updateLocalColorInUserSettings(undefined);
         await updateLocalColorInWorkspace(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -151,14 +151,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color-customizations should be YELLOW', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, yellow);
       });
 
       test('user changes Workspace Settings color to BLUE, color-customizations should be BLUE', async () => {
         await updateLocalColorInWorkspace(azureBlue);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });
@@ -173,7 +173,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(undefined);
         await updateLocalColorInUserSettings(peacockGreen);
         await updateLocalColorInWorkspace(azureBlue);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -186,14 +186,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color should remain BLUE', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });
 
       test('user removes User Settings color, color should remain BLUE', async () => {
         await updateLocalColorInUserSettings(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });
@@ -204,7 +204,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(undefined);
         await updateLocalColorInUserSettings(peacockGreen);
         await updateLocalColorInWorkspace(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -217,14 +217,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color-customizations should be YELLOW', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, yellow);
       });
 
       test('user removes User Settings color, color-customizations should be unapplied', async () => {
         await updateLocalColorInUserSettings(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.ok(!appliedColor);
       });
@@ -235,7 +235,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(undefined);
         await updateLocalColorInUserSettings(undefined);
         await updateLocalColorInWorkspace(azureBlue);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -248,14 +248,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color-customizations should be BLUE', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });
 
       test('user removes Workspace Settings color, color-customizations should be unapplied', async () => {
         await updateLocalColorInWorkspace(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.ok(!appliedColor);
       });
@@ -266,7 +266,7 @@ suite('Manual Editing of Settings', () => {
         remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(undefined);
         await updateLocalColorInUserSettings(undefined);
         await updateLocalColorInWorkspace(undefined);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
       });
       teardown(() => {
         remoteNameStub.restore();
@@ -279,14 +279,14 @@ suite('Manual Editing of Settings', () => {
 
       test('user changes User Settings color to YELLOW, color-customizations should be YELLOW', async () => {
         await updateLocalColorInUserSettings(yellow);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, yellow);
       });
 
       test('user changes Workspace Settings color to BLUE, color-customizations should be BLUE', async () => {
         await updateLocalColorInWorkspace(azureBlue);
-        await applyColor(getPeacockColor());
+        await applyColor(getPeacockColor(), true);
         const appliedColor = getCurrentColorBeforeAdjustments();
         assert.equal(appliedColor, azureBlue);
       });

--- a/src/test/suite/remote.test.ts
+++ b/src/test/suite/remote.test.ts
@@ -41,7 +41,7 @@ suite('Remote Integration', () => {
     // Go to remote env
     const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
     // Set remote color
-    await applyColor(getPeacockRemoteColor());
+    await applyColor(getPeacockRemoteColor(), true);
 
     const peacockRemoteColor = getEnvironmentAwareColor();
     remoteNameStub.restore();
@@ -61,7 +61,7 @@ suite('Remote Integration', () => {
     // Go to remote env
     const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.wsl);
     // Set remote color
-    await applyColor(getPeacockRemoteColor());
+    await applyColor(getPeacockRemoteColor(), true);
     const peacockRemoteColor = getEnvironmentAwareColor();
     remoteNameStub.restore();
 
@@ -69,7 +69,7 @@ suite('Remote Integration', () => {
     const remoteNameStub2 = sinon.stub(vscode.env, 'remoteName').value(undefined);
     // Follow the logic that runs when we activate ...
     const color = getEnvironmentAwareColor();
-    await applyColor(color);
+    await applyColor(color, true);
 
     const peacockLocalColor = getEnvironmentAwareColor();
     remoteNameStub2.restore();


### PR DESCRIPTION
Fixes: #360

 - Add a parameter to the `applyColor` function that allows the consumer to specify whether or not to update the workspace config
 - Fix typos in source comments
 - Fix typo in function name `updateDarkenLightenPercentage`
 - Update all references to `applyColor` accordingly

The issue was that on the `activate` function routine, the `applyColor` function was called during the `addRemoteIntegration` invocation. Workspace settings were updated regardless, of whether or not they needed to be. See #360 for more details.