### PR TITLE
feature/activeBackground

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -10,13 +10,7 @@
 
 ## How to Test
 
-- ...
-
-## What to Check
-
-Verify that the following are valid
-
-- ...
+- `npm test`
 
 ## Checklist of changes included
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 !docs/.vuepress/dist
 out-cov
 coverage
+xunit.xml

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -12,9 +12,10 @@ meta:
 
 All notable changes to the code will be documented in this file.
 
-## Next
+## 3.6.0
 
-- Fixed broken links in changelog
+- [`activitybar.activeBackground` is now set the same as the activity bar's background](https://github.com/johnpapa/vscode-peacock/issues/345)
+- Fixed [broken links in changelog](https://github.com/johnpapa/vscode-peacock/issues/362)
 
 ## 3.5.0
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -16,6 +16,7 @@ All notable changes to the code will be documented in this file.
 
 - [`activitybar.activeBackground` is now set the same as the activity bar's background](https://github.com/johnpapa/vscode-peacock/issues/345)
 - Fixed [broken links in changelog](https://github.com/johnpapa/vscode-peacock/issues/362)
+- Fixed typos in [functions and comments](https://github.com/johnpapa/vscode-peacock/pull/361)
 
 ## 3.5.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-peacock",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -316,7 +316,10 @@ function collectActivityBarSettings(
   if (isAffectedSettingSelected(AffectedSettings.ActivityBar)) {
     const activityBarStyle = getElementStyle(backgroundHex, ElementNames.activityBar);
     activityBarSettings[ColorSettings.activityBar_background] = activityBarStyle.backgroundHex;
-    activityBarSettings[ColorSettings.activityBar_activeBorder] =
+    activityBarSettings[ColorSettings.activityBar_activeBackground] =
+      activityBarStyle.backgroundHex;
+
+      activityBarSettings[ColorSettings.activityBar_activeBorder] =
       activityBarStyle.badgeBackgroundHex;
 
     if (!keepForegroundColor) {

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -80,7 +80,7 @@ export function getUserConfig() {
 
 export function getCurrentColorBeforeAdjustments() {
   /**
-   * Useful if we dont want the
+   * Useful if we don't want the
    *       peacock color but instead to calculate it from
    *       the current customized colors
    *

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -82,7 +82,7 @@ export async function updateLightForegroundColor(value: string) {
   return await updateGlobalConfiguration(StandardSettings.LightForegroundColor, value);
 }
 
-export async function updateDarkenLightenPrecentage(value: number) {
+export async function updateDarkenLightenPercentage(value: number) {
   return await updateGlobalConfiguration(StandardSettings.DarkenLightenPercentage, value);
 }
 

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -32,7 +32,7 @@ export async function updateWorkspaceConfiguration(colorCustomizations: {} | und
   if (isObjectEmpty(colorCustomizations)) {
     // We are receiving an empty object, so let's make it undefined.
     // This means we can skip writing the workbench.colorCustomizations section
-    // if one doesnt already exist.
+    // if one doesn't already exist.
     colorCustomizations = undefined;
   }
 

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -29,7 +29,7 @@ export async function migrateFromMementoToSettingsAsNeeded() {
   // The v2 memento is gone, so no need to migrate.
   if (peacockColorMemento) {
     Logger.info('Migration: Migrating from peacock memento to peacock.color setting.');
-    // Remove the v2 memento (it's ok if it doesnt exist)
+    // Remove the v2 memento (it's ok if it doesn't exist)
     await State.extensionContext.workspaceState.update(peacockColorMementoName, undefined);
   } else {
     /**

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -55,6 +55,7 @@ export enum ColorSettings {
   activityBar_foreground = 'activityBar.foreground',
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',
   activityBar_activeBorder = 'activityBar.activeBorder',
+  activityBar_activeBackground = 'activityBar.activeBackground',
   activityBar_badgeBackground = 'activityBarBadge.background',
   activityBar_badgeForeground = 'activityBarBadge.foreground',
   statusBar_background = 'statusBar.background',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -129,6 +129,7 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.titleBar_inactiveBackground]);
       assert.ok(!config[ColorSettings.titleBar_activeForeground]);
       assert.ok(!config[ColorSettings.activityBar_background]);
+      assert.ok(!config[ColorSettings.activityBar_activeBackground]);
       assert.ok(!config[ColorSettings.activityBar_foreground]);
       assert.ok(!config[ColorSettings.activityBar_inactiveForeground]);
       assert.ok(!config[ColorSettings.activityBar_activeBorder]);
@@ -282,6 +283,7 @@ async function testsDoesNotSetColorCustomizationsForAffectedElements() {
   assert.ok(!config[ColorSettings.activityBar_inactiveForeground]);
   assert.ok(!config[ColorSettings.statusBar_foreground]);
   assert.ok(!config[ColorSettings.statusBar_background]);
+  assert.ok(!config[ColorSettings.activityBar_activeBackground]);
   assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
   // reset
@@ -320,6 +322,7 @@ async function testsSetsColorCustomizationsForAffectedElements() {
 
   const activityBarStyle = getElementStyle(peacockGreen, 'activityBar');
   assert.equal(activityBarStyle.backgroundHex, config[ColorSettings.activityBar_background]);
+  assert.equal(activityBarStyle.backgroundHex, config[ColorSettings.activityBar_activeBackground]);
   assert.equal(activityBarStyle.badgeBackgroundHex, config[ColorSettings.activityBar_activeBorder]);
 
   assert.ok(

--- a/src/test/suite/built-in-colors.test.ts
+++ b/src/test/suite/built-in-colors.test.ts
@@ -85,6 +85,7 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.titleBar_activeBackground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
+      assert.ok(!config[ColorSettings.activityBar_activeBackground]);
       assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
       await removeExtraSetting(extraSettingName);
@@ -96,6 +97,7 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.titleBar_activeBackground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
+      assert.ok(!config[ColorSettings.activityBar_activeBackground]);
       assert.ok(!config[ColorSettings.activityBar_activeBorder]);
     });
 


### PR DESCRIPTION
# Title

## Purpose

- [`activitybar.activeBackground` is now set the same as the activity bar's background](https://github.com/johnpapa/vscode-peacock/issues/345)
- This is not a bug, but it it does fix a problem where Peacock is used with some themes. 
- closes #345

## What

- added activity bar's active background. some themes are setting this color, and peacock was not setting it. this meant that the activity bar would have a color that clashed when using those themes. thus, peacock now sets the `activitybar.activeBackground` color the same as the activityBar background

Notice the following image. The toolbar on the left is what peacock used to look like if a thee colored the activitybar activebackground. The image on the right shows what this fix does.

![image](https://user-images.githubusercontent.com/1202528/76249993-c579ff80-621a-11ea-8128-7c5864c872af.png)

## How to Test

- `npm test`

## Checklist of changes included

- [x] CHANGELOG updated
- [x] README updated
- [x] Tests updated/added
- [x] Prettier formatting
- [x] console.log removed
- [x] Dead code removed
- [x] Unnecessary comments removed
- [x] Images updated (if applicable)
- [x] Version updated everywhere
