### PR TITLE
added sash hover border to the accent border collection, and made the accents default to being true. This helps keep the theme of Peacock without clashing colors that a theme may have mixed with Peacock.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,10 @@
     "titleBar.activeBackground": "#1857a4",
     "titleBar.activeForeground": "#e7e7e7",
     "titleBar.inactiveBackground": "#1857a499",
-    "titleBar.inactiveForeground": "#e7e7e799"
+    "titleBar.inactiveForeground": "#e7e7e799",
+    "editorGroup.border": "#1f6fd0",
+    "panel.border": "#1f6fd0",
+    "sideBar.border": "#1f6fd0"
   },
   "workbench.activityBar.visible": true,
   "workbench.statusBar.visible": true,

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -14,6 +14,10 @@ All notable changes to the code will be documented in this file.
 
 ## 3.10.0
 
+- Added `sash.hoverBorder` to the Accent Borders
+
+  - Changed default value for setting `affectAccentBorders` to true. Accent borders in vs code were clashing contrasts, since the introduction of [sash.hoverBorder](https://code.visualstudio.com/updates/v1_52#_sash-hover-border-color).
+
 - Added support for Peacock as a VS Code web extension [PR 461](https://github.com/johnpapa/vscode-peacock/pull/461)
 
   - The VS Code team recently launched VS Code for the web with [github.dev](https://docs.github.com/en/codespaces/developing-in-codespaces/web-based-editor)! You can read the full guide for extension authors creating and migrating extensions here: [Web Extensions
@@ -23,7 +27,7 @@ All notable changes to the code will be documented in this file.
     - Thanks to [@tanhakabir](https://github.com/tanhakabir) for the core contribution!
 
 - Set border of remote status bar [PR 451](https://github.com/johnpapa/vscode-peacock/pull/451)
-    - Thanks to [@ndrake](https://github.com/ndrake) for the core contribution!
+  - Thanks to [@ndrake](https://github.com/ndrake) for the core contribution!
 
 ## 3.9.1
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -55,28 +55,28 @@ Commands can be found in the command palette. Look for commands beginning with "
 
 ## Settings
 
-| Property                            | Description                                                                                             |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                |
-| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                  |
-| peacock.affectDebuggingStatusBar    | Specifies whether Peacock should affect the status bar while debugging. Defaults to false.              |
-| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))   |
-| peacock.affectAccentBorders         | Specifies whether Peacock should affect accent borders (panel, sideBar, editorGroup) Defaults to false. |
-| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                 |
-| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                      |
-| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                 |
-| peacock.favoriteColors              | array of objects for color names and hex values                                                         |
-| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                   |
-| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                               |
-| peacock.darkForeground              | override for the dark foreground                                                                        |
-| peacock.lightForeground             | override for the light foreground                                                                       |
-| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                           |
-| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color |
-| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                |
-| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                             |
-| peacock.color                       | The Peacock color that will be applied to workspaces                                                    |
-| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                               |
-| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                              |
+| Property                            | Description                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                            |
+| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                              |
+| peacock.affectDebuggingStatusBar    | Specifies whether Peacock should affect the status bar while debugging. Defaults to false.                          |
+| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))               |
+| peacock.affectAccentBorders         | Specifies whether Peacock should affect accent borders (panel, sideBar, editorGroup, sash border) Defaults to true. |
+| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
+| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
+| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |
+| peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
+| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
+| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                           |
+| peacock.darkForeground              | override for the dark foreground                                                                                    |
+| peacock.lightForeground             | override for the light foreground                                                                                   |
+| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                       |
+| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color             |
+| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                            |
+| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                         |
+| peacock.color                       | The Peacock color that will be applied to workspaces                                                                |
+| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                                           |
+| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                                          |
 
 ### Favorite Colors
 

--- a/package.json
+++ b/package.json
@@ -182,8 +182,8 @@
       "properties": {
         "peacock.affectAccentBorders": {
           "type": "boolean",
-          "default": false,
-          "description": "Specifies whether Peacock should affect the accent borders (sideBar, editorGroup, panel)."
+          "default": true,
+          "description": "Specifies whether Peacock should affect the accent borders (sideBar, editorGroup, panel, sash border)."
         },
         "peacock.affectActivityBar": {
           "type": "boolean",

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -393,6 +393,7 @@ function collectAccentBorderSettings(backgroundHex: string) {
     accentBorderSettings[ColorSettings.accentBorders_panelBorder] = color;
     accentBorderSettings[ColorSettings.accentBorders_sideBarBorder] = color;
     accentBorderSettings[ColorSettings.accentBorders_editorGroupBorder] = color;
+    accentBorderSettings[ColorSettings.accentBorders_sashHover] = color;
   }
   if (isAffectedSettingSelected(AffectedSettings.TabActiveBorder)) {
     accentBorderSettings[ColorSettings.tabActiveBorder] = color;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -59,6 +59,7 @@ export enum ColorSettings {
   accentBorders_editorGroupBorder = 'editorGroup.border',
   accentBorders_panelBorder = 'panel.border',
   accentBorders_sideBarBorder = 'sideBar.border',
+  accentBorders_sashHover = 'sash.hoverBorder',
   statusBar_border = 'statusBar.border',
   statusBar_background = 'statusBar.background',
   statusBar_foreground = 'statusBar.foreground',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -146,6 +146,7 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.accentBorders_panelBorder]);
       assert.ok(!config[ColorSettings.accentBorders_sideBarBorder]);
       assert.ok(!config[ColorSettings.accentBorders_editorGroupBorder]);
+      assert.ok(!config[ColorSettings.accentBorders_sashHover]);
       assert.ok(!config[ColorSettings.tabActiveBorder]);
     });
 


### PR DESCRIPTION
added sash hover border to the accent border collection, and made the accents default to being true. This helps keep the theme of Peacock without clashing colors that a theme may have mixed with Peacock.