### PR TITLE
Feat/same remote local color

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,11 @@
           "default": "",
           "description": "The Peacock color that will be applied to remote workspaces."
         },
+        "peacock.sameRemoteLocalColor": {
+          "type": "boolean",
+          "default": false,
+          "description": "set same local color on setting remote color"
+        },
         "peacock.showColorInStatusBar": {
           "type": "boolean",
           "default": true,

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -225,6 +225,10 @@ export function getSurpriseMeOnStartup() {
   return readConfiguration<boolean>(StandardSettings.SurpriseMeOnStartup, false);
 }
 
+export function getSameRemoteLocalColor() {
+  return readConfiguration<boolean>(StandardSettings.SameRemoteLocalColor, false);
+}
+
 export function getAffectedElements() {
   return {
     activityBar: readConfiguration<boolean>(AffectedSettings.ActivityBar) || false,

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -13,7 +13,7 @@ import {
   isObjectEmpty,
 } from '../models';
 import { Logger } from '../logging';
-import { getFavoriteColors, getColorCustomizationConfigFromWorkspace } from './read-configuration';
+import { getFavoriteColors, getColorCustomizationConfigFromWorkspace,getSameRemoteLocalColor } from './read-configuration';
 import { LiveShareSettings } from '../live-share';
 
 export async function updateGlobalConfiguration(setting: AllSettings, value?: any) {
@@ -120,16 +120,31 @@ export async function updatePeacockRemoteColorInUserSettings(color: string | und
   const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
   return await config.update(section, color, ConfigurationTarget.Global);
 }
-
-export async function updatePeacockColor(color: string | undefined) {
+export async function updatePeacockColorOnly(color: string | undefined ) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.Color}`;
   return await config.update(section, color, ConfigurationTarget.Workspace);
+} 
+export async function updatePeacockRemoteColorOnly(color: string | undefined) {
+  const config = vscode.workspace.getConfiguration();
+  const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
+  return await config.update(section, color, ConfigurationTarget.Workspace);
 }
+export async function updatePeacockColor(color: string | undefined ) {
+  const config = vscode.workspace.getConfiguration();
+  const section = `${extensionShortName}.${StandardSettings.Color}`;
+  if (getSameRemoteLocalColor()){
+    await updatePeacockRemoteColorOnly(color);
+  }
+  return await config.update(section, color, ConfigurationTarget.Workspace);
+} 
 
 export async function updatePeacockRemoteColor(color: string | undefined) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
+  if  (getSameRemoteLocalColor()){
+    await updatePeacockColorOnly(color);
+  }
   return await config.update(section, color, ConfigurationTarget.Workspace);
 }
 

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -13,7 +13,11 @@ import {
   isObjectEmpty,
 } from '../models';
 import { Logger } from '../logging';
-import { getFavoriteColors, getColorCustomizationConfigFromWorkspace,getSameRemoteLocalColor } from './read-configuration';
+import {
+  getFavoriteColors,
+  getColorCustomizationConfigFromWorkspace,
+  getSameRemoteLocalColor,
+} from './read-configuration';
 import { LiveShareSettings } from '../live-share';
 
 export async function updateGlobalConfiguration(setting: AllSettings, value?: any) {
@@ -120,29 +124,29 @@ export async function updatePeacockRemoteColorInUserSettings(color: string | und
   const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
   return await config.update(section, color, ConfigurationTarget.Global);
 }
-export async function updatePeacockColorOnly(color: string | undefined ) {
+export async function updatePeacockColorOnly(color: string | undefined) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.Color}`;
   return await config.update(section, color, ConfigurationTarget.Workspace);
-} 
+}
 export async function updatePeacockRemoteColorOnly(color: string | undefined) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
   return await config.update(section, color, ConfigurationTarget.Workspace);
 }
-export async function updatePeacockColor(color: string | undefined ) {
+export async function updatePeacockColor(color: string | undefined) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.Color}`;
-  if (getSameRemoteLocalColor()){
+  if (getSameRemoteLocalColor()) {
     await updatePeacockRemoteColorOnly(color);
   }
   return await config.update(section, color, ConfigurationTarget.Workspace);
-} 
+}
 
 export async function updatePeacockRemoteColor(color: string | undefined) {
   const config = vscode.workspace.getConfiguration();
   const section = `${extensionShortName}.${StandardSettings.RemoteColor}`;
-  if  (getSameRemoteLocalColor()){
+  if (getSameRemoteLocalColor()) {
     await updatePeacockColorOnly(color);
   }
   return await config.update(section, color, ConfigurationTarget.Workspace);

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -10,6 +10,7 @@ export enum StandardSettings {
   KeepForegroundColor = 'keepForegroundColor',
   LightForegroundColor = 'lightForegroundColor',
   RemoteColor = 'remoteColor',
+  SameRemoteLocalColor = 'sameRemoteLocalColor',
   ShowColorInStatusBar = 'showColorInStatusBar',
   SurpriseMeFromFavoritesOnly = 'surpriseMeFromFavoritesOnly',
   SurpriseMeOnStartup = 'surpriseMeOnStartup',


### PR DESCRIPTION
I experience a lot of unexpected color switches when I open the same folder inside docker container or outside of docker container, local folder / when opened through ssh remote. 

I found when opened outside container, it would reset all colors if "peacock.color" not set (when in container it just sets "peacock.remoteColor"). So hopefully this would provide an option to opt out of current behavior and get a stable color when switching how the same folder/workspace is worked with.  Whether make it default is up to you. My preference is make it true by default.

Fixes https://github.com/johnpapa/vscode-peacock/issues/272