### PR TITLE
Removed activityBarBorder setting from being colorful . It was matching the badge, which was no longer uniform with the activitybar. For example a bright red, on blue at times. Instead, by not setting this, it defaults to the foreground color of the badge, thus matching the color setting for the activitybar and its badge icon color.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,6 @@
   "workbench.colorCustomizations": {
     "sash.hoverBorder": "#1857a4",
     "activityBar.activeBackground": "#1857a4",
-    "activityBar.activeBorder": "#530c2c",
     "activityBar.background": "#1857a4",
     "activityBar.foreground": "#e7e7e7",
     "activityBar.inactiveForeground": "#e7e7e799",

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -328,9 +328,6 @@ function collectActivityBarSettings(
     activityBarSettings[ColorSettings.activityBar_activeBackground] =
       activityBarStyle.backgroundHex;
 
-    activityBarSettings[ColorSettings.activityBar_activeBorder] =
-      activityBarStyle.badgeBackgroundHex;
-
     if (!keepForegroundColor) {
       activityBarSettings[ColorSettings.activityBar_foreground] = activityBarStyle.foregroundHex;
       activityBarSettings[ColorSettings.activityBar_inactiveForeground] =

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -53,7 +53,6 @@ export enum ElementNames {
 
 export enum ColorSettings {
   activityBar_activeBackground = 'activityBar.activeBackground',
-  activityBar_activeBorder = 'activityBar.activeBorder',
   activityBar_background = 'activityBar.background',
   activityBar_foreground = 'activityBar.foreground',
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -250,7 +250,7 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.activityBar_activeBackground]);
       assert.ok(!config[ColorSettings.activityBar_foreground]);
       assert.ok(!config[ColorSettings.activityBar_inactiveForeground]);
-      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
+      // assert.ok(!config[ColorSettings.activityBar_activeBorder]);
       assert.ok(!config[ColorSettings.statusBar_foreground]);
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.statusBar_debuggingBorder]);
@@ -503,7 +503,7 @@ async function testsDoesNotSetColorCustomizationsForAffectedElements() {
   assert.ok(!config[ColorSettings.statusBar_foreground]);
   assert.ok(!config[ColorSettings.statusBar_background]);
   assert.ok(!config[ColorSettings.activityBar_activeBackground]);
-  assert.ok(!config[ColorSettings.activityBar_activeBorder]);
+  // assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
   // reset
   await updateAffectedElements(allAffectedElements);
@@ -542,7 +542,6 @@ async function testsSetsColorCustomizationsForAffectedElements() {
   const activityBarStyle = getElementStyle(peacockGreen, 'activityBar');
   assert.equal(activityBarStyle.backgroundHex, config[ColorSettings.activityBar_background]);
   assert.equal(activityBarStyle.backgroundHex, config[ColorSettings.activityBar_activeBackground]);
-  assert.equal(activityBarStyle.badgeBackgroundHex, config[ColorSettings.activityBar_activeBorder]);
 
   assert.ok(
     shouldKeepColorTest(

--- a/src/test/suite/built-in-colors.test.ts
+++ b/src/test/suite/built-in-colors.test.ts
@@ -86,7 +86,6 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
       assert.ok(!config[ColorSettings.activityBar_activeBackground]);
-      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
 
       await removeExtraSetting(extraSettingName);
     });
@@ -98,7 +97,7 @@ suite('can set color to built-in color', () => {
       assert.ok(!config[ColorSettings.statusBar_background]);
       assert.ok(!config[ColorSettings.activityBar_background]);
       assert.ok(!config[ColorSettings.activityBar_activeBackground]);
-      assert.ok(!config[ColorSettings.activityBar_activeBorder]);
+      // assert.ok(!config[ColorSettings.activityBar_activeBorder]);
     });
 
     test('removes peacockColor', async () => {


### PR DESCRIPTION
Removed activityBarBorder setting from being colorful . It was matching the badge, which was no longer uniform with the activitybar. For example a bright red, on blue at times. Instead, by not setting this, it defaults to the foreground color of the badge, thus matching the color setting for the activitybar and its badge icon color.