### PR TITLE
Command-center

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,5 +12,5 @@ features:
     details: Color your Visual Studio Code editor uniquely when you are using the remote integration features.
   - title: Live Share
     details: Color your Visual Studio Code editor uniquely when you are in a Live Share session as a Guest or a Host
-footer: MIT Licensed | Copyright © 2019-present John Papa | current version 4.0.1
+footer: MIT Licensed | Copyright © 2019-present John Papa | current version 4.1.0
 ---

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -16,9 +16,10 @@ All notable changes to the code will be documented in this file.
 
 - Added color settings for new VS Code feature for CommandCenter
 
-  - TODO
+  - added commandCenter.border property to be set using same logic as titleBar inactiveForeground (`commandCenter.border = titleBar.inactiveForeground`)
 
 - Minor changes
+
   - Removed activityBarBorder setting from being colorful. It was matching the badge, which was no longer uniform with the activitybar. For example a bright red, on blue at times. Instead, by not setting this, it defaults to the foreground color of the badge, thus matching the color setting for the activitybar and its badge icon color.
   - Remove and ignore .DS_Store [PR 490](https://github.com/johnpapa/vscode-peacock/pull/490). Thanks to [@Etheryte](https://github.com/Etheryte) for the core contribution!
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -15,10 +15,12 @@ All notable changes to the code will be documented in this file.
 ## 4.1.0
 
 - Added color settings for new VS Code feature for CommandCenter
+
   - TODO
 
 - Minor changes
   - Removed activityBarBorder setting from being colorful. It was matching the badge, which was no longer uniform with the activitybar. For example a bright red, on blue at times. Instead, by not setting this, it defaults to the foreground color of the badge, thus matching the color setting for the activitybar and its badge icon color.
+  - Remove and ignore .DS_Store [PR 490](https://github.com/johnpapa/vscode-peacock/pull/490). Thanks to [@Etheryte](https://github.com/Etheryte) for the core contribution!
 
 ## 4.0.1
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -12,6 +12,14 @@ meta:
 
 All notable changes to the code will be documented in this file.
 
+## 4.1.0
+
+- Added color settings for new VS Code feature for CommandCenter
+  - TODO
+
+- Minor changes
+  - Removed activityBarBorder setting from being colorful. It was matching the badge, which was no longer uniform with the activitybar. For example a bright red, on blue at times. Instead, by not setting this, it defaults to the foreground color of the badge, thus matching the color setting for the activitybar and its badge icon color.
+
 ## 4.0.1
 
 - Badges udpates to use <https://shields.io/> in readme and docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-peacock",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
@@ -439,5 +439,11 @@
     "hooks": {
       "pre-commit": "npm run pretty"
     }
+  },
+  "__metadata": {
+    "id": "5a7017bf-c571-4d77-b902-6e56b16f539a",
+    "publisherDisplayName": "John Papa",
+    "publisherId": "4434843a-4ebf-4f44-84f5-4176380c492d",
+    "isPreReleaseVersion": false
   }
 }

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -310,6 +310,7 @@ function collectTitleBarSettings(backgroundHex: string, keepForegroundColor: boo
       titleBarSettings[ColorSettings.titleBar_activeForeground] = titleBarStyle.foregroundHex;
       titleBarSettings[ColorSettings.titleBar_inactiveForeground] =
         titleBarStyle.inactiveForegroundHex;
+      titleBarSettings[ColorSettings.commandCenter_border] = titleBarStyle.inactiveForegroundHex;
     }
   }
   return titleBarSettings;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -58,6 +58,7 @@ export enum ColorSettings {
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',
   activityBar_badgeBackground = 'activityBarBadge.background',
   activityBar_badgeForeground = 'activityBarBadge.foreground',
+  commandCenter_border = 'commandCenter.border',
   editorGroupBorder = 'editorGroup.border',
   panelBorder = 'panel.border',
   sideBarBorder = 'sideBar.border',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -496,6 +496,11 @@ async function testsDoesNotSetColorCustomizationsForAffectedElements() {
     ),
   );
 
+  assert.equal(
+    config[ColorSettings.commandCenter_border],
+    config[ColorSettings.titleBar_inactiveForeground],
+  );
+
   // All others should not exist
   assert.ok(!config[ColorSettings.activityBar_background]);
   assert.ok(!config[ColorSettings.activityBar_foreground]);
@@ -529,6 +534,11 @@ async function testsSetsColorCustomizationsForAffectedElements() {
   assert.equal(
     titleBarStyle.inactiveBackgroundHex,
     config[ColorSettings.titleBar_inactiveBackground],
+  );
+
+  assert.equal(
+    config[ColorSettings.commandCenter_border],
+    config[ColorSettings.titleBar_inactiveForeground],
   );
 
   assert.ok(


### PR DESCRIPTION
Set the commandCenter.* properties based on the existing color choices for:

commandCenter.border = titleBar.inactiveForeground; // should it ?
commandCenter.activeBackground = titleBar.activeBackground;
commandCenter.background = titleBar.inactiveBackground;
