### PR TITLE
refactor: break non live-share circular dependencies

### DIFF
--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -1,19 +1,19 @@
 import * as tinycolor from 'tinycolor2';
 
 import {
-  ColorAdjustment,
-  ReadabilityRatios,
-  inactiveElementAlpha,
-  ColorSettings,
-  ColorAdjustmentOptions,
-  defaultAmountToDarkenLighten,
-  defaultSaturation,
-} from './models';
-import {
-  getColorCustomizationConfigFromWorkspace,
   getDarkForegroundColorOrOverride,
   getLightForegroundColorOrOverride,
-} from './configuration';
+} from './configuration/foreground-color';
+import { getColorCustomizationConfigFromWorkspace } from './configuration/workspace';
+import {
+  ColorAdjustment,
+  ColorAdjustmentOptions,
+  ColorSettings,
+  ReadabilityRatios,
+  defaultAmountToDarkenLighten,
+  defaultSaturation,
+  inactiveElementAlpha,
+} from './models';
 
 export function getColorHex(color = '') {
   return formatHex(tinycolor(color));

--- a/src/configuration/foreground-color.ts
+++ b/src/configuration/foreground-color.ts
@@ -1,0 +1,18 @@
+import { ForegroundColors, StandardSettings } from '../models/enums';
+import { readConfiguration } from './utils';
+
+export function getDarkForegroundColorOrOverride() {
+  return getDarkForegroundColor() || ForegroundColors.DarkForeground;
+}
+
+export function getLightForegroundColorOrOverride() {
+  return getLightForegroundColor() || ForegroundColors.LightForeground;
+}
+
+export function getDarkForegroundColor() {
+  return readConfiguration<string>(StandardSettings.DarkForegroundColor, '');
+}
+
+export function getLightForegroundColor() {
+  return readConfiguration<string>(StandardSettings.LightForegroundColor, '');
+}

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,2 +1,5 @@
+export * from './foreground-color';
 export * from './read-configuration';
 export * from './update-configuration';
+export * from './utils';
+export * from './workspace';

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -1,36 +1,36 @@
 import * as vscode from 'vscode';
 import {
-  ColorSettings,
-  Sections,
-  StandardSettings,
-  extensionShortName,
-  IFavoriteColors,
-  favoriteColorSeparator,
-  IPeacockElementAdjustments,
-  IElementStyle,
-  ColorAdjustment,
-  AllSettings,
-  AffectedSettings,
-  IPeacockAffectedElementSettings,
-  ISettingsIndexer,
-  ElementNames,
-  ColorAdjustmentOptions,
-  IElementColors,
-  ForegroundColors,
-  defaultAmountToDarkenLighten,
-  ColorSource,
-} from '../models';
-import {
   getAdjustedColorHex,
-  getBadgeBackgroundColorHex,
   getBackgroundHoverColorHex,
+  getBadgeBackgroundColorHex,
   getDebuggingBackgroundColorHex,
   getForegroundColorHex,
   getInactiveBackgroundColorHex,
   getInactiveForegroundColorHex,
 } from '../color-library';
 import { LiveShareSettings } from '../live-share';
+import {
+  AffectedSettings,
+  ColorAdjustment,
+  ColorAdjustmentOptions,
+  ColorSettings,
+  ColorSource,
+  ElementNames,
+  IElementColors,
+  IElementStyle,
+  IFavoriteColors,
+  IPeacockAffectedElementSettings,
+  IPeacockElementAdjustments,
+  ISettingsIndexer,
+  Sections,
+  StandardSettings,
+  defaultAmountToDarkenLighten,
+  extensionShortName,
+  favoriteColorSeparator,
+} from '../models';
 import { sortSettingsIndexer } from '../object-library';
+import { getDarkForegroundColor, getLightForegroundColor } from './foreground-color';
+import { readConfiguration } from './utils';
 
 const { workspace } = vscode;
 
@@ -54,17 +54,6 @@ export function getColorCustomizationConfig() {
   // If we want to get just the ones from workspace,
   // we should change functions to use getColorCustomizationConfigFromWorkspace
   return workspace.getConfiguration(Sections.peacockColorCustomizationSection);
-}
-
-export function getColorCustomizationConfigFromWorkspace() {
-  const inspect = workspace.getConfiguration().inspect(Sections.peacockColorCustomizationSection);
-
-  if (!inspect || typeof inspect.workspaceValue !== 'object') {
-    return {};
-  }
-
-  const colorCustomizations: ISettingsIndexer = inspect.workspaceValue as ISettingsIndexer;
-  return colorCustomizations;
 }
 
 export function getPeacockWorkspace() {
@@ -91,13 +80,6 @@ export function getCurrentColorBeforeAdjustments() {
     originalColor = getOriginalColor(color, adjustment);
   }
   return originalColor;
-}
-
-export function readConfiguration<T>(setting: AllSettings, defaultValue?: T | undefined) {
-  const value: T | undefined = workspace
-    .getConfiguration(Sections.peacockSection)
-    .get<T | undefined>(setting, defaultValue);
-  return value as T;
 }
 
 export function isAffectedSettingSelected(affectedSetting: AffectedSettings) {
@@ -134,10 +116,6 @@ export function prepareColors(backgroundHex: string) {
   const newColorCustomizations = sortSettingsIndexer(mergedSettings);
 
   return newColorCustomizations;
-}
-
-export function getDarkForegroundColor() {
-  return readConfiguration<string>(StandardSettings.DarkForegroundColor, '');
 }
 
 export function getEnvironmentAwareColor() {
@@ -178,18 +156,6 @@ export function getPeacockRemoteColor() {
 
 export function getLiveShareColor(liveShareSetting: LiveShareSettings) {
   return readConfiguration<string>(liveShareSetting, '');
-}
-
-export function getDarkForegroundColorOrOverride() {
-  return getDarkForegroundColor() || ForegroundColors.DarkForeground;
-}
-
-export function getLightForegroundColor() {
-  return readConfiguration<string>(StandardSettings.LightForegroundColor, '');
-}
-
-export function getLightForegroundColorOrOverride() {
-  return getLightForegroundColor() || ForegroundColors.LightForeground;
 }
 
 export function getKeepForegroundColor() {
@@ -285,7 +251,7 @@ export function getElementStyle(backgroundHex: string, elementName?: string): IE
 }
 
 export function getAllSettingNames() {
-  const settings = [];
+  const settings: string[] = [];
   const affectedSettings = Object.values(AffectedSettings).map(
     value => `${extensionShortName}.${value}`,
   );

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -1,20 +1,21 @@
 import * as vscode from 'vscode';
 import { ConfigurationTarget } from 'vscode';
+import { LiveShareSettings } from '../live-share';
+import { Logger } from '../logging';
 import {
-  extensionShortName,
+  AffectedSettings,
   AllSettings,
-  Sections,
-  IPeacockElementAdjustments,
-  StandardSettings,
   IFavoriteColors,
   IPeacockAffectedElementSettings,
-  AffectedSettings,
-  starterSetOfFavorites,
+  IPeacockElementAdjustments,
+  Sections,
+  StandardSettings,
+  extensionShortName,
   isObjectEmpty,
+  starterSetOfFavorites,
 } from '../models';
-import { Logger } from '../logging';
-import { getFavoriteColors, getColorCustomizationConfigFromWorkspace } from './read-configuration';
-import { LiveShareSettings } from '../live-share';
+import { getFavoriteColors } from './read-configuration';
+import { getColorCustomizationConfigFromWorkspace } from './workspace';
 
 export async function updateGlobalConfiguration(setting: AllSettings, value?: any) {
   const config = vscode.workspace.getConfiguration();

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+import { AllSettings, Sections } from '../models/enums';
+const { workspace } = vscode;
+
+export function readConfiguration<T>(setting: AllSettings, defaultValue?: T | undefined) {
+  const value: T | undefined = workspace
+    .getConfiguration(Sections.peacockSection)
+    .get<T | undefined>(setting, defaultValue);
+  return value as T;
+}

--- a/src/configuration/workspace.ts
+++ b/src/configuration/workspace.ts
@@ -1,0 +1,13 @@
+import { workspace } from 'vscode';
+import { ISettingsIndexer, Sections } from '../models';
+
+export function getColorCustomizationConfigFromWorkspace() {
+  const inspect = workspace.getConfiguration().inspect(Sections.peacockColorCustomizationSection);
+
+  if (!inspect || typeof inspect.workspaceValue !== 'object') {
+    return {};
+  }
+
+  const colorCustomizations: ISettingsIndexer = inspect.workspaceValue as ISettingsIndexer;
+  return colorCustomizations;
+}

--- a/src/models/extension.ts
+++ b/src/models/extension.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+import { extensionId } from './constants';
+
+export function getExtension() {
+  let extension: vscode.Extension<any> | undefined;
+  const ext = vscode.extensions.getExtension(extensionId);
+  if (!ext) {
+    throw new Error('Extension was not found.');
+  }
+  if (ext) {
+    extension = ext;
+  }
+  return extension;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,20 +1,5 @@
-import * as vscode from 'vscode';
-import { extensionId } from './constants';
-
 export * from './constants';
 export * from './enums';
 export * from './favorites';
 export * from './interfaces';
 export * from './state';
-
-export function getExtension() {
-  let extension: vscode.Extension<any> | undefined;
-  const ext = vscode.extensions.getExtension(extensionId);
-  if (!ext) {
-    throw new Error('Extension was not found.');
-  }
-  if (ext) {
-    extension = ext;
-  }
-  return extension;
-}

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getExtension } from './';
+import { getExtension } from './extension';
 
 export class State {
   private static _extContext: vscode.ExtensionContext;

--- a/src/test/suite/basic.test.ts
+++ b/src/test/suite/basic.test.ts
@@ -1,17 +1,17 @@
-import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 import {
-  IPeacockSettings,
-  ICommand,
+  AffectedSettings,
   Commands,
+  ICommand,
   IConfiguration,
+  IPeacockSettings,
   StandardSettings,
   extensionShortName,
-  AffectedSettings,
-  getExtension,
   timeout,
 } from '../../models';
-import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
+import { getExtension } from '../../models/extension';
+import { setupTest, setupTestSuite, teardownTestSuite } from './lib/setup-teardown-test-suite';
 
 suite('Basic Extension Tests', () => {
   const originalValues = {} as IPeacockSettings;

--- a/src/test/suite/lib/setup-teardown-test-suite.ts
+++ b/src/test/suite/lib/setup-teardown-test-suite.ts
@@ -1,36 +1,36 @@
 import {
-  IPeacockSettings,
-  Commands,
-  ForegroundColors,
-  starterSetOfFavorites,
-  getExtension,
-} from '../../../models';
-import {
   getAffectedElements,
-  getFavoriteColors,
-  updateFavoriteColors,
-  updateElementAdjustments,
-  updateKeepForegroundColor,
-  getKeepForegroundColor,
-  updateSurpriseMeOnStartup,
   getDarkForegroundColor,
+  getFavoriteColors,
+  getKeepBadgeColor,
+  getKeepForegroundColor,
   getLightForegroundColor,
-  updateDarkForegroundColor,
-  updateLightForegroundColor,
-  updateAffectedElements,
-  updateSurpriseMeFromFavoritesOnly,
-  getSurpriseMeFromFavoritesOnly,
-  getShowColorInStatusBar,
-  updateShowColorInStatusBar,
   getPeacockColor,
   getPeacockRemoteColor,
+  getShowColorInStatusBar,
+  getSurpriseMeFromFavoritesOnly,
+  updateAffectedElements,
+  updateDarkForegroundColor,
+  updateElementAdjustments,
+  updateFavoriteColors,
+  updateKeepBadgeColor,
+  updateKeepForegroundColor,
+  updateLightForegroundColor,
   updatePeacockColor,
   updatePeacockRemoteColor,
-  getKeepBadgeColor,
-  updateKeepBadgeColor,
+  updateShowColorInStatusBar,
+  updateSurpriseMeFromFavoritesOnly,
+  updateSurpriseMeOnStartup,
 } from '../../../configuration';
+import {
+  Commands,
+  ForegroundColors,
+  IPeacockSettings,
+  starterSetOfFavorites,
+} from '../../../models';
 
-import { noopElementAdjustments, executeCommand, allAffectedElements } from './constants';
+import { getExtension } from '../../../models/extension';
+import { allAffectedElements, executeCommand, noopElementAdjustments } from './constants';
 
 export async function setupTest() {
   await executeCommand(Commands.resetWorkspaceColors);

--- a/src/test/suite/status-bar.test.ts
+++ b/src/test/suite/status-bar.test.ts
@@ -1,8 +1,9 @@
-import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { IPeacockSettings, Commands, getExtension, peacockGreen } from '../../models';
-import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
+import * as vscode from 'vscode';
+import { Commands, IPeacockSettings, peacockGreen } from '../../models';
+import { getExtension } from '../../models/extension';
 import { getStatusBarItem } from '../../statusbar';
+import { setupTest, setupTestSuite, teardownTestSuite } from './lib/setup-teardown-test-suite';
 
 suite.skip('StatusBar Tests', () => {
   const originalValues = {} as IPeacockSettings;


### PR DESCRIPTION
I'm trying to import this extension and use it in Google, however our TS rules doesn't allow circular dependencies.

Live-share related imports are not needed, hence not resolved.

Output of `npx madge --exclude='live-share' --circular --extensions ts ./`:
```
⠋ Finding files=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.2.0

YOUR TYPESCRIPT VERSION: 5.4.5

Please only submit bug reports when using the officially supported version.

=============
Processed 53 files (3.4s) 

✔ No circular dependency found!
```