### PR TITLE
feat(startup): add deterministic startup colors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -158,6 +158,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "sreyemnayr",
+      "name": "Ryan Meyers",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8558670?v=4",
+      "profile": "https://github.com/sreyemnayr",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -75,6 +75,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
 | peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
 | peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                           |
+| peacock.deterministicOnStartup      | Specifies whether Peacock apply a deterministic random color on startup (based on workspace folder)                 |
 | peacock.darkForeground              | override for the dark foreground                                                                                    |
 | peacock.lightForeground             | override for the light foreground                                                                                   |
 | peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                       |
@@ -160,6 +161,14 @@ When set to true Peacock will not colorize the foreground of any of the affected
 Recommended to remain `false` (the default value).
 
 When set to true Peacock will automatically apply a random color when opening a workspace that does not define color customizations. This can be useful if you frequently open many instances of VS Code and you are interested in identifying them, but are not overly committed to the specific color applied.
+
+If this setting is `true` and there is no peacock color set, then Peacock will choose a new color. If there is already a color set, Peacock will not choose a random color as this would prevent users from choosing a specific color for some workspaces and surprise in others.
+
+### Deterministic on Startup
+
+Recommended to remain `false` (the default value).
+
+When set to true Peacock will automatically apply a deterministic random color (based on a hash of the workspace folder path) when opening a workspace that does not define color customizations. This can be useful if you frequently open many instances of VS Code and you are interested in identifying them, and you want the same color to be chosen for the same workspace folder regardless of the number of times the workspace is opened.
 
 If this setting is `true` and there is no peacock color set, then Peacock will choose a new color. If there is already a color set, Peacock will not choose a random color as this would prevent users from choosing a specific color for some workspaces and surprise in others.
 

--- a/package.json
+++ b/package.json
@@ -367,6 +367,11 @@
           "default": false,
           "description": "Specifies that Peacock should surprise you at the start of every editing session, only when a color isn't already set. "
         },
+        "peacock.deterministicOnStartup": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies that Peacock should surprise you with a deterministic random color (based on workspace folder) at the start of every editing session, only when a color isn't already set. The same color will be chosen for the same workspace folder regardless of the number of times the workspace is opened."
+        },
         "peacock.vslsJoinColor": {
           "type": "string",
           "default": "",
@@ -406,7 +411,7 @@
     "@types/istanbul-lib-source-maps": "^1.2.2",
     "@types/istanbul-reports": "^1.1.2",
     "@types/mocha": "^7.0.2",
-    "@types/node": "12.12.16",
+    "@types/node": "^14.18.63",
     "@types/sinon": "^7.5.2",
     "@types/vscode": "^1.49.0",
     "@types/webpack-env": "^1.16.0",

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -9,6 +9,7 @@ import {
   defaultAmountToDarkenLighten,
   defaultSaturation,
 } from './models';
+import { seededRandom } from './random';
 import {
   getColorCustomizationConfigFromWorkspace,
   getDarkForegroundColorOrOverride,
@@ -133,6 +134,14 @@ export function getDarkenedColorHex(color: string, amount = defaultAmountToDarke
 
 export function getRandomColorHex() {
   return formatHex(tinycolor.random());
+}
+
+export function getSeededRandomColorHex(seed: string) {
+  return formatHex(tinycolor.fromRatio({
+    r: seededRandom(`${seed}-r`),
+    g: seededRandom(`${seed}-g`),
+    b: seededRandom(`${seed}-b`),
+  }));
 }
 
 export function getColorBrightness(input = '') {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,7 @@ import {
   getRandomColorHex,
   getDarkenedColorHex,
   getLightenedColorHex,
+  getSeededRandomColorHex,
 } from './color-library';
 import { applyColor, unapplyColors, updateColorSetting } from './apply-color';
 import { State, peacockGreen, docsUri } from './models';
@@ -17,6 +18,8 @@ import {
   updatePeacockRemoteColor,
   updatePeacockRemoteColorInUserSettings,
   updatePeacockColorInUserSettings,
+  getDeterministicRandomFavoriteColor,
+  getWorkingDirectory,
 } from './configuration';
 import { promptForColor, promptForFavoriteColor, promptForFavoriteColorName } from './inputs';
 
@@ -68,12 +71,12 @@ export async function enterColorHandler(color?: string) {
   return State.extensionContext;
 }
 
-export async function changeColorToRandomHandler() {
+export async function changeColorToRandomHandler(deterministic = false) {
   const surpriseMeFromFavoritesOnly = getSurpriseMeFromFavoritesOnly();
   let color = '';
 
   if (surpriseMeFromFavoritesOnly) {
-    const o = getRandomFavoriteColor();
+    const o = deterministic ? getDeterministicRandomFavoriteColor() : getRandomFavoriteColor();
     if (!o) {
       notify(
         'No favorites exist. Add some favorites if you want to use the surprise me from favorites feature',
@@ -82,7 +85,7 @@ export async function changeColorToRandomHandler() {
     }
     color = o.value;
   } else {
-    color = getRandomColorHex();
+    color = deterministic ? getSeededRandomColorHex(getWorkingDirectory()) : getRandomColorHex();
   }
 
   await applyColor(color);

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -29,13 +29,22 @@ import {
   getInactiveBackgroundColorHex,
   getInactiveForegroundColorHex,
 } from '../color-library';
+import { seededRandomInt } from '../random';
 import { LiveShareSettings } from '../live-share';
 import { sortSettingsIndexer } from '../object-library';
 
 const { workspace } = vscode;
 
+export function getWorkingDirectory() {
+  return vscode.workspace.workspaceFolders?.[0]?.uri.toString() || '';
+}
+
 export function getSurpriseMeFromFavoritesOnly() {
   return readConfiguration<boolean>(StandardSettings.SurpriseMeFromFavoritesOnly, false);
+}
+
+export function getDeterministicOnStartup() {
+  return readConfiguration<boolean>(StandardSettings.DeterministicOnStartup, false);
 }
 
 export function getDarkenLightenPercentage() {
@@ -218,13 +227,28 @@ export function getFavoriteColors() {
 export function getRandomFavoriteColor() {
   const { values: favoriteColors } = getFavoriteColors();
   const currentColor = getEnvironmentAwareColor();
+
   let newColorFromFavorites: IFavoriteColors;
+
   do {
     newColorFromFavorites = favoriteColors[Math.floor(Math.random() * favoriteColors.length)];
   } while (
     favoriteColors.length > 1 &&
-    newColorFromFavorites.value.toLowerCase() === currentColor.toLowerCase()
+      newColorFromFavorites.value.toLowerCase() === currentColor.toLowerCase()
   );
+  
+  return newColorFromFavorites;
+}
+
+export function getDeterministicRandomFavoriteColor() {
+  const { values: favoriteColors } = getFavoriteColors();
+
+  let newColorFromFavorites: IFavoriteColors;
+
+  do {
+    newColorFromFavorites = favoriteColors[seededRandomInt(getWorkingDirectory(), favoriteColors.length - 1)];
+  } while (favoriteColors.length > 1);
+  
   return newColorFromFavorites;
 }
 
@@ -497,6 +521,7 @@ function getAllUserSettings() {
   const keepBadgeColor = getKeepBadgeColor();
   const keepForegroundColor = getKeepForegroundColor();
   const surpriseMeOnStartup = getSurpriseMeOnStartup();
+  const deterministicOnStartup = getDeterministicOnStartup();
   const darkForegroundColor = getDarkForegroundColor();
   const lightForegroundColor = getLightForegroundColor();
   const {
@@ -516,6 +541,7 @@ function getAllUserSettings() {
     keepBadgeColor,
     keepForegroundColor,
     surpriseMeOnStartup,
+    deterministicOnStartup,
     darkForegroundColor,
     lightForegroundColor,
     affectActivityBar,

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -78,6 +78,10 @@ export async function updateSurpriseMeOnStartup(value: boolean) {
   return await updateGlobalConfiguration(StandardSettings.SurpriseMeOnStartup, value);
 }
 
+export async function updateDeterministicOnStartup(value: boolean) {
+  return await updateGlobalConfiguration(StandardSettings.DeterministicOnStartup, value);
+}
+
 export async function updateDarkForegroundColor(value: string) {
   return await updateGlobalConfiguration(StandardSettings.DarkForegroundColor, value);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import {
   inspectColor,
   getCurrentColorBeforeAdjustments,
   getFavoriteColors,
+  getDeterministicOnStartup,
 } from './configuration';
 import { applyColor, updateColorSetting } from './apply-color';
 import { Logger } from './logging';
@@ -140,14 +141,15 @@ export async function checkSurpriseMeOnStartupLogic() {
    * workspace and see it changed to the "surprise" color
    */
   const peacockColor = getEnvironmentAwareColor();
-  if (getSurpriseMeOnStartup()) {
+  const deterministic = getDeterministicOnStartup();
+  if (getSurpriseMeOnStartup() || deterministic) {
     if (peacockColor) {
       const message = `Peacock did not change the color using "surprise me on startup" because the color ${peacockColor} was already set.`;
       Logger.info(message);
       return;
     }
 
-    await changeColorToRandomHandler();
+    await changeColorToRandomHandler(deterministic);
     const color = getEnvironmentAwareColor();
     const message = `Peacock changed the color to ${color}, because the setting is enabled for ${StandardSettings.SurpriseMeOnStartup}`;
     Logger.info(message);

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -14,6 +14,7 @@ export enum StandardSettings {
   SquigglyBeGone = 'squigglyBeGone',
   SurpriseMeFromFavoritesOnly = 'surpriseMeFromFavoritesOnly',
   SurpriseMeOnStartup = 'surpriseMeOnStartup',
+  DeterministicOnStartup = 'deterministicOnStartup',
 }
 
 export enum AffectedSettings {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -66,6 +66,7 @@ export interface IPeacockSettings {
   squigglyBeGone: boolean;
   surpriseMeFromFavoritesOnly: boolean;
   surpriseMeOnStartup: boolean;
+  deterministicOnStartup: boolean;
   color: string;
   remoteColor: string;
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,0 +1,81 @@
+/**
+ * Converts a string to a numeric hash value using FNV-1a algorithm
+ * Provides better distribution for similar strings like file paths
+ * @param str Input string to hash
+ * @returns Numeric hash value
+ */
+const stringToHash = (str: string): number => {
+  let hash = 2166136261; // FNV offset basis
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  return Math.abs(hash >>> 0); // Convert to 32-bit unsigned
+};
+
+/**
+ * Generates a random number between 0 and 1 using a numeric seed
+ * Based on Mulberry32 algorithm
+ * @param seed Numeric seed value or string to hash
+ * @returns Number between 0 and 1
+ */
+export const seededRandom = (seed: number | string): number => {
+  let t = typeof seed === 'string' ? stringToHash(seed) : seed;
+  t += 0x6D2B79F5;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+/**
+ * Gets the number of decimal places in a number
+ * @param num Number to check
+ * @returns Number of decimal places
+ */
+const getDecimalPlaces = (num: number): number => {
+  const match = num.toString().match(/(?:\.(\d+))?$/);
+  if (!match?.[1]) return 0;
+  return match[1].length;
+};
+
+/**
+ * Generates a deterministic random number within a range using a string seed
+ * @param seed String value used as seed
+ * @param max Maximum value (inclusive)
+ * @param min Minimum value (inclusive), defaults to 0
+ * @returns Random number between min and max (order doesn't matter)
+ *          Returns integer if inputs are integers
+ *          Returns decimal if any input is decimal, matching input precision
+ */
+export const seededRandomNumber = (seed: string, max: number, min: number = 0): number => {
+  const actualMin = Math.min(min, max);
+  const actualMax = Math.max(min, max);
+  
+  if (actualMin === actualMax) {
+    return actualMin;
+  }
+
+  const decimals = Math.max(getDecimalPlaces(actualMin), getDecimalPlaces(actualMax));
+  const random = seededRandom(seed);
+  
+  if (decimals === 0) {
+    return Math.floor(random * (actualMax - actualMin + 1)) + actualMin;
+  }
+  
+  const multiplier = Math.pow(10, decimals);
+  const randomValue = random * (actualMax - actualMin) + actualMin;
+  return Math.round(randomValue * multiplier) / multiplier;
+};
+
+/**
+ * Generates a deterministic random integer within a range using a string seed
+ * @param seed String value used as seed
+ * @param max Maximum integer value (inclusive)
+ * @param min Minimum integer value (inclusive), defaults to 0
+ * @returns Random integer between min and max (order doesn't matter)
+ */
+export const seededRandomInt = (seed: string, max: number, min: number = 0): number => {
+  const roundedMin = Math.round(min);
+  const roundedMax = Math.round(max);
+  return Math.round(seededRandomNumber(seed, roundedMax, roundedMin));
+};

--- a/src/test/suite/deterministic-on-startup.test.ts
+++ b/src/test/suite/deterministic-on-startup.test.ts
@@ -1,0 +1,138 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import {
+  Commands,
+  IPeacockSettings,
+  IPeacockAffectedElementSettings,
+  IElementColors,
+  ElementNames,
+} from '../../models';
+import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
+import { executeCommand } from './lib/constants';
+import {
+  getOriginalColorsForAllElements,
+  updateAffectedElements,
+  updateDeterministicOnStartup,
+  getFavoriteColors,
+  updateSurpriseMeFromFavoritesOnly,
+  getEnvironmentAwareColor
+} from '../../configuration';
+import { checkSurpriseMeOnStartupLogic } from '../../extension';
+
+suite('Deterministic on startup', () => {
+  const originalValues = {} as IPeacockSettings;
+
+  suiteSetup(async () => await setupTestSuite(originalValues));
+  suiteTeardown(async () => await teardownTestSuite(originalValues));
+  setup(async () => await setupTest());
+
+  setup(async () => {
+    await executeCommand(Commands.resetWorkspaceColors);
+    await updateAffectedElements({
+      statusBar: true,
+      activityBar: true,
+      titleBar: true,
+    } as IPeacockAffectedElementSettings);
+  });
+
+  test('when not set has no effect if no customizations exist', async () => {
+    await testColorsBeforeAndAfterInitialConfiguration(assert.equal);
+  });
+
+  suite('when set', () => {
+    setup(async () => {
+      await updateDeterministicOnStartup(true);
+    });
+
+    test('applies a deterministic random color if no color customizations exist', async () => {
+      await testColorsBeforeAndAfterInitialConfiguration(assert.notEqual);
+    });
+
+    test('has no effect when color customizations exist', async () => {
+      await vscode.commands.executeCommand(Commands.changeColorToPeacockGreen);
+      await testColorsBeforeAndAfterInitialConfiguration(assert.equal);
+    });
+
+    test('consistently assigns the same color based on the workspace name', async () => { 
+      await testConsistencyOfDeterministicColor();
+    });
+
+    test('obeys favorites when deterministic on startup is set', async () => {
+      await updateSurpriseMeFromFavoritesOnly(true);
+      const { values: favorites } = getFavoriteColors();
+      await testConsistencyOfDeterministicColor();
+      const color = getEnvironmentAwareColor();
+      const match = favorites.find(item => item.value.toLowerCase() === color.toLowerCase());
+      assert.ok(
+        match,
+        `chosen color ${color} is not found in the favorites ${JSON.stringify(favorites)}`
+      );
+      
+      
+    });
+
+    teardown(async () => {
+      await updateDeterministicOnStartup(false);
+    });
+  });
+
+  async function testColorsBeforeAndAfterInitialConfiguration(assertEquality: EqualityAssertion) {
+    const colors1: IElementColors = getOriginalColorsForAllElements();
+    await checkSurpriseMeOnStartupLogic();
+    const colors2: IElementColors = getOriginalColorsForAllElements();
+    assertEquality(colors1[ElementNames.activityBar], colors2[ElementNames.activityBar]);
+    assertEquality(colors1[ElementNames.statusBar], colors2[ElementNames.statusBar]);
+    assertEquality(colors1[ElementNames.titleBar], colors2[ElementNames.titleBar]);
+  }
+
+  async function testConsistencyOfDeterministicColor() {
+    await vscode.commands.executeCommand(Commands.resetWorkspaceColors);
+    const colors_pre_0: IElementColors = getOriginalColorsForAllElements();
+    await checkSurpriseMeOnStartupLogic();
+    const colors_post_0: IElementColors = getOriginalColorsForAllElements();
+    await vscode.commands.executeCommand(Commands.resetWorkspaceColors);
+    const colors_pre_1: IElementColors = getOriginalColorsForAllElements();
+    await checkSurpriseMeOnStartupLogic();
+    const colors_post_1: IElementColors = getOriginalColorsForAllElements();
+    await vscode.commands.executeCommand(Commands.resetWorkspaceColors);
+    const colors_pre_2: IElementColors = getOriginalColorsForAllElements();
+    await checkSurpriseMeOnStartupLogic();
+    const colors_post_2: IElementColors = getOriginalColorsForAllElements();
+
+    // Check that the no-colors are the same
+    assert.equal(colors_pre_0[ElementNames.activityBar], colors_pre_1[ElementNames.activityBar]);
+    assert.equal(colors_pre_0[ElementNames.statusBar], colors_pre_0[ElementNames.statusBar]);
+    assert.equal(colors_pre_0[ElementNames.titleBar], colors_pre_0[ElementNames.titleBar]);
+
+    assert.equal(colors_pre_1[ElementNames.activityBar], colors_pre_2[ElementNames.activityBar]);
+    assert.equal(colors_pre_1[ElementNames.statusBar], colors_pre_2[ElementNames.statusBar]);
+    assert.equal(colors_pre_1[ElementNames.titleBar], colors_pre_2[ElementNames.titleBar]);
+
+    // Check that the colors are different before and after assignment
+    assert.notEqual(colors_pre_0[ElementNames.activityBar], colors_post_0[ElementNames.activityBar]);
+    assert.notEqual(colors_pre_0[ElementNames.statusBar], colors_post_0[ElementNames.statusBar]);
+    assert.notEqual(colors_pre_0[ElementNames.titleBar], colors_post_0[ElementNames.titleBar]);
+
+    assert.notEqual(colors_pre_1[ElementNames.activityBar], colors_post_1[ElementNames.activityBar]);
+    assert.notEqual(colors_pre_1[ElementNames.statusBar], colors_post_1[ElementNames.statusBar]);
+    assert.notEqual(colors_pre_1[ElementNames.titleBar], colors_post_1[ElementNames.titleBar]);
+
+    assert.notEqual(colors_pre_2[ElementNames.activityBar], colors_post_2[ElementNames.activityBar]);
+    assert.notEqual(colors_pre_2[ElementNames.statusBar], colors_post_2[ElementNames.statusBar]);
+    assert.notEqual(colors_pre_2[ElementNames.titleBar], colors_post_2[ElementNames.titleBar]);
+
+    // Check that the colors are the same between runs
+    assert.equal(colors_post_0[ElementNames.activityBar], colors_post_1[ElementNames.activityBar]);
+    assert.equal(colors_post_0[ElementNames.statusBar], colors_post_1[ElementNames.statusBar]);
+    assert.equal(colors_post_0[ElementNames.titleBar], colors_post_1[ElementNames.titleBar]);
+
+    assert.equal(colors_post_1[ElementNames.activityBar], colors_post_2[ElementNames.activityBar]);
+    assert.equal(colors_post_1[ElementNames.statusBar], colors_post_2[ElementNames.statusBar]);
+    assert.equal(colors_post_1[ElementNames.titleBar], colors_post_2[ElementNames.titleBar]);
+
+  }
+
+  interface EqualityAssertion {
+    (actual: any, expected: any, message?: string | Error | undefined): void;
+  }
+});

--- a/src/test/suite/lib/setup-teardown-test-suite.ts
+++ b/src/test/suite/lib/setup-teardown-test-suite.ts
@@ -12,7 +12,10 @@ import {
   updateElementAdjustments,
   updateKeepForegroundColor,
   getKeepForegroundColor,
+  getSurpriseMeOnStartup,
   updateSurpriseMeOnStartup,
+  getDeterministicOnStartup,
+  updateDeterministicOnStartup,
   getDarkForegroundColor,
   getLightForegroundColor,
   updateDarkForegroundColor,
@@ -54,12 +57,15 @@ export async function setupTestSuite(
   originalValues.showColorInStatusBar = getShowColorInStatusBar();
   originalValues.color = getPeacockColor();
   originalValues.remoteColor = getPeacockRemoteColor();
+  originalValues.deterministicOnStartup = getDeterministicOnStartup();
+  originalValues.surpriseMeOnStartup = getSurpriseMeOnStartup();
 
   // Set the test values
   await updateAffectedElements(allAffectedElements);
   await updateFavoriteColors(starterSetOfFavorites);
   await updateKeepForegroundColor(false);
   await updateSurpriseMeOnStartup(false);
+  await updateDeterministicOnStartup(false);
   await updateElementAdjustments(noopElementAdjustments);
   await updateDarkForegroundColor(ForegroundColors.DarkForeground);
   await updateLightForegroundColor(ForegroundColors.LightForeground);
@@ -85,6 +91,7 @@ export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await updateKeepBadgeColor(originalValues.keepBadgeColor);
   await updateSurpriseMeFromFavoritesOnly(originalValues.surpriseMeFromFavoritesOnly);
   await updateSurpriseMeOnStartup(originalValues.surpriseMeOnStartup);
+  await updateDeterministicOnStartup(originalValues.deterministicOnStartup);
   await updateShowColorInStatusBar(originalValues.showColorInStatusBar);
   await updatePeacockColor(originalValues.color);
   await updatePeacockRemoteColor(originalValues.remoteColor);


### PR DESCRIPTION
Using a hash of the root workspace folder as a seed, always chooses the same random color for a given workspace. Helpful to have a consistent color regardless of ability to maintain settings, etc.