### PR TITLE
Feature/excluded settings

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -71,6 +71,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                          |
 | peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
 | peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
+| peacock.excludedSettings            | Specify VS Code color keys that Peacock should never modify or delete, even to reset their values.                  |
 | peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |
 | peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
 | peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
@@ -125,6 +126,27 @@ The `Peacock: Save Current Color as Favorite Color` feature allows you to save t
 You can tell peacock which parts of VS Code will be affected by when you select a color. You can do this by checking the appropriate setting that applies to the elements you want to be colored. These include examples such as affectEditorGroupBorder, affectPanelBorder, affectSideBarBorder, affectSashHover.
 
 ![affected elements](/assets/affected-settings.png)
+
+### Excluded Settings
+
+Even if you tell Peacock to not "affect" a given element, E.G., `"peacock.affectStatusBar": false`,
+the related settings in the workspace's settings.json can still be deleted, as a part of cleaning
+up or reseting "dirty" state in the settings.  This can be problematic if a user has workspace
+specific settings of their own that he or she doesn't want Peacock to touch.  This setting can be
+set before installing Peacock to avoid the extension interacting with those settings at all.  For example, this:
+```javascript
+"peacock.excludedSettings": [
+    "statusBar.background",
+    "statusBar.foreground"
+],
+```
+Will prevent Peacock from modifying or deleting these values in the workspace's settings.json:
+```javascript
+"workbench.colorCustomizations": {
+    "statusBar.background": "#f3dcb6",
+    "statusBar.foreground": "#004572"
+}
+```
 
 ### Element Adjustments
 

--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
         "peacock.excludedSettings": {
           "type": "array",
           "default": [],
-          "description": "An array of VS Code color keys (e.g. 'activityBar.background') that Peacock should never modify or delete."
+          "description": "An array of VS Code color keys (e.g. 'activityBar.background') that Peacock should never modify or delete.  This will prevent Peacock from even resetting their values."
         },
         "peacock.elementAdjustments": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -240,6 +240,11 @@
           "default": "",
           "description": "The Peacock color that will be applied to workspaces. This should only be set at the workspace level."
         },
+        "peacock.excludedSettings": {
+          "type": "array",
+          "default": [],
+          "description": "An array of VS Code color keys (e.g. 'activityBar.background') that Peacock should never modify or delete."
+        },
         "peacock.elementAdjustments": {
           "type": "object",
           "properties": {

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -152,12 +152,14 @@ export function isValidColorInput(input: string) {
   return isValid;
 }
 
-export function deletePeacocksColorCustomizations() {
+export function deletePeacocksColorCustomizations(excludedSettings: string[] = []) {
   const newColorCustomizations = getColorCustomizationConfigFromWorkspace();
 
-  Object.values(ColorSettings).forEach(setting => {
-    delete newColorCustomizations[setting];
-  });
+  Object.values(ColorSettings)
+    .filter(setting => !excludedSettings.includes(setting))
+    .forEach(setting => {
+      delete newColorCustomizations[setting];
+    });
   return newColorCustomizations;
 }
 

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -5,6 +5,7 @@ export enum StandardSettings {
   DarkenLightenPercentage = 'darkenLightenPercentage',
   DarkForegroundColor = 'darkForegroundColor',
   ElementAdjustments = 'elementAdjustments',
+  ExcludedSettings = 'excludedSettings',
   FavoriteColors = 'favoriteColors',
   KeepBadgeColor = 'keepBadgeColor',
   KeepForegroundColor = 'keepForegroundColor',


### PR DESCRIPTION
Even if you tell Peacock to not "affect" a given element, E.G., `"peacock.affectStatusBar": false`, the related settings in the workspace's settings.json can still be deleted, as a part of cleaning up or reseting "dirty" state in the settings.  This can be problematic if a user has workspace specific settings of their own that he or she doesn't want Peacock to touch.  This new setting allows the user to exclude those settings.

See the corresponding issue that I opened: https://github.com/johnpapa/vscode-peacock/issues/575