### PR TITLE
fix: colorize commandCenter foreground

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "statusBarItem.remoteBackground": "#1857a4",
     "statusBarItem.remoteForeground": "#e7e7e7",
     "activityBar.activeBorder": "#530c2c",
-    "commandCenter.border": "#e7e7e799"
+    "commandCenter.border": "#e7e7e799",
+    "commandCenter.foreground": "#e7e7e7"
   }
 }

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -318,6 +318,7 @@ function collectTitleBarSettings(backgroundHex: string, keepForegroundColor: boo
       titleBarSettings[ColorSettings.titleBar_inactiveForeground] =
         titleBarStyle.inactiveForegroundHex;
       titleBarSettings[ColorSettings.commandCenter_border] = titleBarStyle.inactiveForegroundHex;
+      titleBarSettings[ColorSettings.commandCenter_foreground] = titleBarStyle.foregroundHex;
     }
   }
   return titleBarSettings;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -60,6 +60,7 @@ export enum ColorSettings {
   activityBar_badgeBackground = 'activityBarBadge.background',
   activityBar_badgeForeground = 'activityBarBadge.foreground',
   commandCenter_border = 'commandCenter.border',
+  commandCenter_foreground = 'commandCenter.foreground',
   editorGroupBorder = 'editorGroup.border',
   panelBorder = 'panel.border',
   sideBarBorder = 'sideBar.border',

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -501,6 +501,11 @@ async function testsDoesNotSetColorCustomizationsForAffectedElements() {
     config[ColorSettings.titleBar_inactiveForeground],
   );
 
+  assert.equal(
+    config[ColorSettings.commandCenter_foreground],
+    config[ColorSettings.titleBar_activeForeground],
+  );
+
   // All others should not exist
   assert.ok(!config[ColorSettings.activityBar_background]);
   assert.ok(!config[ColorSettings.activityBar_foreground]);


### PR DESCRIPTION
With the new feature that shows agent information in the header, the text in it is no longer styled and often is not visible.

<img width="1356" height="102" alt="Screenshot 2026-04-02 at 15 17 31@2x" src="https://github.com/user-attachments/assets/48b25f40-b443-4637-b573-7314ac5c1319" />

This pull request updates that text to use the same color as the other icons in the header (`titleBar.activeForeground`).

<img width="1338" height="72" alt="Screenshot 2026-04-02 at 15 28 41@2x" src="https://github.com/user-attachments/assets/8deed919-61a2-48c2-9901-4e6fac43afda" />
