### PR TITLE
fix: skip redundant workspace settings writes on activation

### DIFF
--- a/src/apply-color.ts
+++ b/src/apply-color.ts
@@ -15,6 +15,7 @@ import {
   getBackgroundColorHex,
   deletePeacocksColorCustomizations,
 } from './color-library';
+import { settingsIndexersAreEqual } from './object-library';
 // import { ConfigurationTarget } from 'vscode';
 
 export async function unapplyColors() {
@@ -25,7 +26,15 @@ export async function unapplyColors() {
 
   // Overwite color customizations, without the peacock ones.
   // This preserves any extra ones someone might have.
+  const existing = getColorCustomizationConfigFromWorkspace();
   const colorCustomizationsWithPeacock = deletePeacocksColorCustomizations();
+  if (settingsIndexersAreEqual(existing, colorCustomizationsWithPeacock)) {
+    // Nothing to remove — avoid a redundant write that would dirty
+    // .vscode/settings.json on every activation (and race other extension
+    // hosts in editors like Cursor that load extensions in multiple hosts).
+    updateStatusBar();
+    return;
+  }
   await updateWorkspaceConfiguration(colorCustomizationsWithPeacock);
   updateStatusBar();
 }
@@ -85,6 +94,18 @@ export async function applyColor(input: string) {
   const updatedColors = prepareColors(color);
 
   const colorCustomizations = mergeColorCustomizations(existingColors, updatedColors);
+
+  if (settingsIndexersAreEqual(existingColors, colorCustomizations)) {
+    // The existing workspace customizations already match what Peacock would
+    // write — skip the no-op write so we don't dirty .vscode/settings.json on
+    // every activation. This also prevents races in editors like Cursor that
+    // load the extension in multiple parallel extension hosts (user,
+    // retrieval, agent-exec, ...), each of which would otherwise write the
+    // same value back at startup.
+    updateStatusBar();
+    Logger.info(`${extensionShortName}: Peacock is now using ${color}`);
+    return color;
+  }
 
   await updateWorkspaceConfiguration(colorCustomizations);
   updateStatusBar();

--- a/src/object-library.ts
+++ b/src/object-library.ts
@@ -7,3 +7,12 @@ export function sortSettingsIndexer(unordered: ISettingsIndexer) {
     .forEach(key => (ordered[key] = unordered[key]));
   return ordered;
 }
+
+export function settingsIndexersAreEqual(a: ISettingsIndexer, b: ISettingsIndexer) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every(key => a[key] === b[key]);
+}


### PR DESCRIPTION
## Summary

On activation, `applyColor` (and `unapplyColors`) unconditionally writes `workbench.colorCustomizations` to the workspace, even when the resulting object would be byte-identical to what's already on disk. This change adds a shallow-equality check on the merged customization map and skips the write when nothing would change.

## Why

This is the same root cause as #559 and #360: every editor restart dirties `.vscode/settings.json`. Worth re-opening because Cursor (and any editor that splits extensions across multiple extension hosts) makes it actively destructive rather than just annoying.

In Cursor, the same workspace runs four parallel extension hosts (`user`, `retrieval`, `always-local`, `agent-exec`). I verified Peacock loads in at least the `user` and `retrieval` hosts simultaneously — both PIDs emit the `tinycolor2 → punycode` deprecation warning at activation time:

```
[Extension Host] (node:62580) [DEP0040] DeprecationWarning: punycode...
[Extension Host] (node:62598) [DEP0040] DeprecationWarning: punycode...
```

Each of those activations independently calls `addRemoteIntegration → applyColor(peacockColor) → updateWorkspaceConfiguration`, so the hosts race to rewrite `.vscode/settings.json` on every open. That breaks the file in subtle ways for users who have stable peacock-managed customizations checked into the repo.

VS Code is not affected because it has a single extension host per window, so the redundant write is only annoying, not destructive.

## Change

Two narrow edits in `src/apply-color.ts`, plus a small `settingsIndexersAreEqual` helper in `src/object-library.ts`:

- `applyColor` — after computing the merged customization map, compare to the existing one; if equal, skip the `updateWorkspaceConfiguration` call (still updates the status bar and logs).
- `unapplyColors` — same idea: if there are no Peacock-managed keys to remove, skip the write.

No public API change. Behavior is unchanged whenever the workspace actually needs updating: choosing a favorite, editing `peacock.color`, removing a color customization, the config-change handler in `extension.ts`, etc., all still write as before.

## Test plan

- [x] `npx tsc -p ./` — no new type errors in `src/` (pre-existing `node_modules/@playwright/test/...` errors unrelated)
- [x] `npx eslint ./src --ext .js,.ts` — clean
- [x] Manual: in Cursor, reset `.vscode/settings.json` → reopen → file unchanged
- [x] Manual: in Cursor, change `peacock.color` → settings.json updates as before
- [ ] Existing extension test suite (haven't run locally — would appreciate a CI run)

Refs #559 #360