### PR TITLE
fix: add skipLibCheck for TS 3.9 compat with newer deps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"skipLibCheck": true,
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
The webpack 5.106 upgrade (#600) pulled in `@types/eslint` that uses TypeScript syntax (`rest element type`) not supported by TS 3.9. This broke `tsc` and `npm run test-compile`.

`skipLibCheck: true` skips type checking of `.d.ts` files in `node_modules` — standard practice for projects with older TypeScript versions. This does not affect type checking of the project's own source code.

**Verified:** `npm run lint` ✅, `npm run test-compile` ✅ (tsc + webpack)