### PR TITLE
test: add unit tests for object-library

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,8 @@ VS Code extension written in TypeScript, bundled with Webpack, published to the 
 - Run unit tests: `npm test`
 - Run e2e tests: `npm run test:e2e`
 - Tests use `testworkspace/` as the VS Code workspace
+- **Every bug fix must include a regression test** that fails without the fix and passes with it
+- **Every new feature must include unit tests** covering the happy path and relevant edge cases
 
 ## Code Style
 
@@ -46,6 +48,7 @@ VS Code extension written in TypeScript, bundled with Webpack, published to the 
 |---|---|
 | New command added | `package.json` (contributes.commands + menus), `src/models/enums.ts` (Commands enum), `src/commands.ts`, `src/extension.ts` (register), `src/test/`, `docs/guide/`, `docs/changelog/README.md` |
 | New setting added | `package.json` (contributes.configuration), `src/models/enums.ts` (StandardSettings or AffectedSettings enum), `src/configuration/read-configuration.ts`, `src/test/`, `docs/guide/`, `docs/changelog/README.md` |
+| Bug fix | `src/test/` (add a regression test that fails without the fix), `docs/changelog/README.md` |
 | Color application logic | `src/apply-color.ts`, `src/color-library.ts`, related unit tests |
 | Live Share integration | `src/live-share/`, `src/live-share/liveshare-commands.ts`, `package.json` (vsls dependency), related tests, run `npm run test-all` |
 | Remote features | `src/remote/`, related tests |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@ npm run test-all                # Run unit + Live Share tests
 - E2e tests live in `e2e/` and use Playwright to capture docs screenshots
 - The `testworkspace/` directory is used as a VS Code workspace during tests
 
+**Test requirements:**
+- Every bug fix must include a regression test that fails without the fix and passes with it
+- Every new feature must include unit tests covering the happy path and relevant edge cases
+- Never merge code that reduces the passing test count
+
 ## Key Patterns and Conventions
 
 - **Commands** are registered in `extension.ts` and implemented in `commands.ts`

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -17,6 +17,7 @@ All notable changes to the code will be documented in this file.
 - Modern Peacock-branded design with responsive layout, client-side search, and syntax highlighting
 - Added 69 Playwright e2e tests covering pages, navigation, images, links, styling, and search
 - Added CI workflow with lint, build, and tests on all PRs
+- Added unit tests for `object-library` (sortSettingsIndexer, settingsIndexersAreEqual)
 - Added AI-Ready badge, AGENTS.md, copilot-instructions.md, and copilot-setup-steps.yml
 - Upgraded issue templates from markdown to YAML issue forms
 - Added Dependabot for npm and GitHub Actions dependencies

--- a/src/test/suite/object-library.test.ts
+++ b/src/test/suite/object-library.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import { sortSettingsIndexer, settingsIndexersAreEqual } from '../../object-library';
+
+suite('Object Library', () => {
+  suite('sortSettingsIndexer', () => {
+    test('returns keys in alphabetical order', () => {
+      const unordered = { zebra: '#000', apple: '#111', mango: '#222' };
+      const ordered = sortSettingsIndexer(unordered);
+      const keys = Object.keys(ordered);
+      assert.deepStrictEqual(keys, ['apple', 'mango', 'zebra']);
+    });
+
+    test('preserves values after sorting', () => {
+      const unordered = { b: '#222', a: '#111' };
+      const ordered = sortSettingsIndexer(unordered);
+      assert.equal(ordered['a'], '#111');
+      assert.equal(ordered['b'], '#222');
+    });
+
+    test('handles empty object', () => {
+      const ordered = sortSettingsIndexer({});
+      assert.deepStrictEqual(ordered, {});
+    });
+
+    test('handles single key', () => {
+      const ordered = sortSettingsIndexer({ only: '#fff' });
+      assert.deepStrictEqual(Object.keys(ordered), ['only']);
+    });
+  });
+
+  suite('settingsIndexersAreEqual', () => {
+    test('returns true for identical objects', () => {
+      const a = { 'titleBar.activeBackground': '#ff0000', 'statusBar.background': '#00ff00' };
+      const b = { 'titleBar.activeBackground': '#ff0000', 'statusBar.background': '#00ff00' };
+      assert.ok(settingsIndexersAreEqual(a, b));
+    });
+
+    test('returns true for two empty objects', () => {
+      assert.ok(settingsIndexersAreEqual({}, {}));
+    });
+
+    test('returns false when key counts differ', () => {
+      const a = { 'titleBar.activeBackground': '#ff0000' };
+      const b = { 'titleBar.activeBackground': '#ff0000', 'statusBar.background': '#00ff00' };
+      assert.ok(!settingsIndexersAreEqual(a, b));
+    });
+
+    test('returns false when a is empty and b has keys', () => {
+      assert.ok(!settingsIndexersAreEqual({}, { key: 'value' }));
+    });
+
+    test('returns false when values differ for same keys', () => {
+      const a = { 'titleBar.activeBackground': '#ff0000' };
+      const b = { 'titleBar.activeBackground': '#00ff00' };
+      assert.ok(!settingsIndexersAreEqual(a, b));
+    });
+
+    test('returns false when keys differ but count is same', () => {
+      const a = { 'titleBar.activeBackground': '#ff0000' };
+      const b = { 'statusBar.background': '#ff0000' };
+      assert.ok(!settingsIndexersAreEqual(a, b));
+    });
+
+    test('does not mutate input objects', () => {
+      const a = { key1: 'val1', key2: 'val2' };
+      const b = { key1: 'val1', key2: 'val2' };
+      settingsIndexersAreEqual(a, b);
+      assert.deepStrictEqual(a, { key1: 'val1', key2: 'val2' });
+      assert.deepStrictEqual(b, { key1: 'val1', key2: 'val2' });
+    });
+
+    test('handles many Peacock color settings', () => {
+      const colors = {
+        'activityBar.background': '#ff0000',
+        'activityBar.foreground': '#ffffff',
+        'activityBarBadge.background': '#00ff00',
+        'statusBar.background': '#ff0000',
+        'statusBar.foreground': '#ffffff',
+        'titleBar.activeBackground': '#ff0000',
+        'titleBar.activeForeground': '#ffffff',
+        'titleBar.inactiveBackground': '#ff000099',
+        'titleBar.inactiveForeground': '#ffffff99',
+      };
+      const clone = { ...colors };
+      assert.ok(settingsIndexersAreEqual(colors, clone));
+
+      clone['statusBar.background'] = '#0000ff';
+      assert.ok(!settingsIndexersAreEqual(colors, clone));
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds 11 unit tests for `object-library.ts` — the highest-value test coverage gap.

## New Tests — `object-library.test.ts`

**`sortSettingsIndexer`** (4 tests)
- Returns keys in alphabetical order
- Preserves values after sorting
- Handles empty object
- Handles single key

**`settingsIndexersAreEqual`** (7 tests)
- Returns true for identical objects
- Returns true for two empty objects
- Returns false when key counts differ
- Returns false when a is empty and b has keys
- Returns false when values differ for same keys
- Returns false when keys differ but count is same
- Does not mutate input objects
- Handles many Peacock color settings (realistic scenario)

## Why

`settingsIndexersAreEqual` caused a regression in #601 — these tests would have caught the shared-reference bug where the function compared a mutated object against itself (always returning true), causing workspace color writes to be silently skipped.

## Checklist

- [x] Lint passes
- [x] Build passes
- [x] Changelog updated
- [x] No existing tests modified
