### PR TITLE
fix: fall back to peacock.color when remoteColor is not set

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -10,6 +10,10 @@ All notable changes to the code will be documented in this file.
 - Added color picker support in `settings.json` for all Peacock color settings (#531)
 - Skip redundant workspace settings writes on activation — prevents races in multi-host editors like Cursor (#601)
 
+### Bug Fixes
+
+- Fixed remote color fallback: `peacock.color` is now used when `peacock.remoteColor` is not set in remote contexts (devcontainers, SSH, WSL) (#522, #459)
+
 ### Docs & Infrastructure
 
 - Migrated documentation site from VuePress to Docsify, deployed via GitHub Pages

--- a/src/remote/integration.ts
+++ b/src/remote/integration.ts
@@ -20,7 +20,7 @@ export async function addRemoteIntegration(context: vscode.ExtensionContext) {
   // await vscode.commands.executeCommand('setContext', 'peacock:remote', remoteExtensions);
 
   if (vscode.env.remoteName) {
-    const remoteColor = getPeacockRemoteColor();
+    const remoteColor = getPeacockRemoteColor() || getPeacockColor();
     await applyColor(remoteColor);
   } else {
     const peacockColor = getPeacockColor();

--- a/src/test/suite/remote.test.ts
+++ b/src/test/suite/remote.test.ts
@@ -9,6 +9,7 @@ import {
   peacockGreen,
   azureBlue,
   StandardSettings,
+  State,
 } from '../../models';
 import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
 import { isValidColorInput } from '../../color-library';
@@ -222,5 +223,37 @@ suite('Remote Integration', () => {
     assert.ok(isValidColorInput(value));
     assert.ok(value !== azureBlue);
     assert.equal(value, peacockGreen);
+  });
+
+  test('when in remote and remoteColor is not set, peacock.color is used as fallback', async () => {
+    await updatePeacockColor(peacockGreen);
+    await updatePeacockRemoteColor(undefined);
+
+    const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.devContainer);
+    const { addRemoteIntegration } = await import('../../remote/integration');
+    await addRemoteIntegration(State.extensionContext);
+    remoteNameStub.restore();
+
+    const config = getColorCustomizationConfig();
+    const value = config[ColorSettings.titleBar_activeBackground];
+
+    assert.ok(isValidColorInput(value), 'Color should be valid when falling back to peacock.color');
+    assert.equal(value, peacockGreen, 'Should fall back to peacock.color when remoteColor is not set');
+  });
+
+  test('when in remote and remoteColor is set, remoteColor takes priority over peacock.color', async () => {
+    await updatePeacockColor(peacockGreen);
+    await updatePeacockRemoteColor(azureBlue);
+
+    const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.devContainer);
+    const { addRemoteIntegration } = await import('../../remote/integration');
+    await addRemoteIntegration(State.extensionContext);
+    remoteNameStub.restore();
+
+    const config = getColorCustomizationConfig();
+    const value = config[ColorSettings.titleBar_activeBackground];
+
+    assert.ok(isValidColorInput(value), 'Color should be valid');
+    assert.equal(value, azureBlue, 'Should use remoteColor when it is set');
   });
 });


### PR DESCRIPTION
## What

Fixes the remote color fallback behavior to match documentation: when `peacock.remoteColor` is not set, `peacock.color` is now used as fallback in remote contexts (devcontainers, SSH, WSL).

Fixes #522
Fixes #459

## The Bug

When opening a workspace in a remote context with only `peacock.color` set (no `peacock.remoteColor`), all workspace colors were being **wiped** instead of falling back to the local color.

**Root cause:** `addRemoteIntegration()` called `applyColor(getPeacockRemoteColor())` — when `remoteColor` was unset, this passed an empty string to `applyColor`, which triggered `unapplyColors()` and deleted all `workbench.colorCustomizations`.

## The Fix

One-line change in `src/remote/integration.ts:23`:
```typescript
const remoteColor = getPeacockRemoteColor() || getPeacockColor();
```

## Tests Added

Two regression tests in `remote.test.ts`:
1. **Fallback test** — when `remoteColor` is unset and `peacock.color` is set, colors are applied in remote context
2. **Priority test** — when both are set, `remoteColor` takes priority

## Checklist

- [x] Lint passes
- [x] Build passes
- [x] Regression tests added
- [x] Changelog updated
- [x] Fixes documented behavior gap
