### PR TITLE
fix: use contrasting accent color for remote indicator badge

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -10,6 +10,10 @@ All notable changes to the code will be documented in this file.
 - Added color picker support in `settings.json` for all Peacock color settings (#531)
 - Skip redundant workspace settings writes on activation — prevents races in multi-host editors like Cursor (#601)
 
+### Bug Fixes
+
+- Fixed remote indicator badge blending into status bar: badge now uses a contrasting accent color instead of the same color as the status bar (#473)
+
 ### Docs & Infrastructure
 
 - Migrated documentation site from VuePress to Docsify, deployed via GitHub Pages

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -360,7 +360,8 @@ function collectStatusBarSettings(backgroundHex: string, keepForegroundColor: bo
     statusBarSettings[ColorSettings.statusBar_background] = statusBarStyle.backgroundHex;
     statusBarSettings[ColorSettings.statusBarItem_hoverBackground] =
       statusBarStyle.backgroundHoverHex;
-    statusBarSettings[ColorSettings.statusBarItem_remoteBackground] = statusBarStyle.backgroundHex;
+    statusBarSettings[ColorSettings.statusBarItem_remoteBackground] =
+      statusBarStyle.badgeBackgroundHex;
 
     if (isAffectedSettingSelected(AffectedSettings.StatusAndTitleBorders)) {
       statusBarSettings[ColorSettings.statusBar_border] = statusBarStyle.backgroundHex;

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -322,6 +322,25 @@ suite('Affected elements', () => {
       assert.ok(remoteForeground);
     });
 
+    test('remote badge background differs from status bar background for contrast', async () => {
+      await updateAffectedElements({
+        statusBar: true,
+      } as IPeacockAffectedElementSettings);
+
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      const statusBarBg = config[ColorSettings.statusBar_background];
+      const remoteBadgeBg = config[ColorSettings.statusBarItem_remoteBackground];
+      assert.ok(statusBarBg, 'statusBar.background should be set');
+      assert.ok(remoteBadgeBg, 'statusBarItem.remoteBackground should be set');
+      assert.notEqual(
+        remoteBadgeBg,
+        statusBarBg,
+        'Remote badge should differ from status bar for visibility',
+      );
+    });
+
     test('status bar remote host styles are not set when status bar is affected', async () => {
       await updateAffectedElements({
         statusBar: false,


### PR DESCRIPTION
## What

Fixes the remote indicator badge (bottom-left of status bar) being invisible because it was the same color as the status bar background.

Fixes #473

## The Bug

`collectStatusBarSettings()` set `statusBarItem.remoteBackground` to the exact same hex as `statusBar.background`, making the remote connection badge blend in completely. VS Code's default for this token is a prominent blue (`#007ACC`) that visually distinguishes the badge — Peacock was overriding it with an identical color.

## The Fix

Changed `statusBarItem.remoteBackground` to use `badgeBackgroundHex` — a readable accent color computed by `getReadableAccentColorHex()`. This is the same approach already used for activity bar badges (`activityBarBadge.background`), ensuring the remote indicator is visually distinct from the status bar.

**1 line changed** in `src/configuration/read-configuration.ts:363`:
```typescript
// Before:
statusBarSettings[ColorSettings.statusBarItem_remoteBackground] = statusBarStyle.backgroundHex;
// After:
statusBarSettings[ColorSettings.statusBarItem_remoteBackground] = statusBarStyle.badgeBackgroundHex;
```

## Tests Added

1 regression test in `affected-elements.test.ts`:
- **Remote badge background differs from status bar background** — asserts the two colors are not equal

## Checklist

- [x] Lint passes
- [x] Build passes
- [x] Regression test added
- [x] Changelog updated
