### PR TITLE
fix: reset reliably clears workspace colors

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -13,6 +13,7 @@ All notable changes to the code will be documented in this file.
 ### Bug Fixes
 
 - Fixed remote indicator badge blending into status bar: badge now uses a contrasting accent color instead of the same color as the status bar (#473)
+- Fixed "Reset Workspace Colors" not clearing colors when `peacock.color` was already undefined — reset now directly removes color customizations instead of relying on a configuration change event (#554)
 
 ### Docs & Infrastructure
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,6 +38,7 @@ export async function showDocumentationHandler() {
 
 export async function resetWorkspaceColorsHandler() {
   await resetLiveSharePreviousColors();
+  await unapplyColors();
   await updatePeacockColor(undefined);
   await updatePeacockRemoteColor(undefined);
   return State.extensionContext;

--- a/src/test/suite/reset.test.ts
+++ b/src/test/suite/reset.test.ts
@@ -63,4 +63,25 @@ suite('Reset Tests', () => {
     assert.ok(!color, 'Color should be undefined since there are no peacock.color in any settings');
     assert.ok(!appliedColors[ElementNames.statusBar], 'No colors should be applied');
   });
+
+  test('reset clears workspace colors even when peacock.color is already undefined', async () => {
+    // Simulate the case where colors were applied externally or peacock.color
+    // was already cleared but workbench.colorCustomizations still has entries
+    await updatePeacockColorInUserSettings(undefined);
+    await updatePeacockColor(undefined);
+
+    // Apply colors directly without setting peacock.color
+    const { applyColor } = await import('../../apply-color');
+    await applyColor(azureBlue);
+
+    // Verify colors are applied
+    const appliedBefore = getOriginalColorsForAllElements();
+    assert.ok(appliedBefore[ElementNames.statusBar], 'Colors should be applied before reset');
+
+    // Reset should still clear them even though peacock.color is already undefined
+    await executeCommand(Commands.resetWorkspaceColors);
+
+    const appliedAfter = getOriginalColorsForAllElements();
+    assert.ok(!appliedAfter[ElementNames.statusBar], 'Colors should be cleared after reset');
+  });
 });


### PR DESCRIPTION
## What

Fixes "Reset Workspace Colors" silently failing when `peacock.color` is already undefined.

Fixes #554

## The Bug

`resetWorkspaceColorsHandler()` relied entirely on the `onDidChangeConfiguration` event to trigger `unapplyColors()`. But when `peacock.color` was already `undefined`, calling `updatePeacockColor(undefined)` was a no-op — no config change event fired — and `workbench.colorCustomizations` was never cleared.

## The Fix

Added a direct `await unapplyColors()` call in `resetWorkspaceColorsHandler()` before clearing the Peacock settings. This ensures color customizations are always removed regardless of the current settings state.

## Test Added

Regression test: applies colors directly (without setting `peacock.color`), then runs reset, and asserts all color customizations are cleared.

## Checklist

- [x] Lint passes
- [x] Build passes
- [x] Regression test added
- [x] Changelog updated
