### PR TITLE
chore: improve AI-readiness (setup steps, CI paths, changelog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,20 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'images/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'images/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,21 @@
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run test-compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # CHANGELOG
 
-The changelog can be found in the extensive [documentation here](https://johnpapa.github.io/vscode-peacock/) which includes a guide on how to use Peacock and a [changelog](https://johnpapa.github.io/vscode-peacock/#/changelog/)
+The changelog can be found in the extensive [documentation here](https://johnpapa.github.io/vscode-peacock/) which includes a guide on how to use Peacock and a [changelog](https://johnpapa.github.io/vscode-peacock/#/changelog/).
+
+> **Note:** The authoritative changelog is maintained at [`docs/changelog/README.md`](docs/changelog/README.md).


### PR DESCRIPTION
## Changes

- **Add `copilot-setup-steps.yml`** — mirrors CI (Node 20, `npm ci`, `npm run test-compile`) so the Copilot coding agent knows how to set up the environment
- **Add `paths-ignore` to CI workflow** — skips full build/test for docs-only changes
- **Improve `CHANGELOG.md` pointer** — adds explicit note pointing to the authoritative changelog at `docs/changelog/README.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>