### PR TITLE
fix: medium gray titleBar foreground for Cursor IDE icon visibility (#647)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-peacock",
-  "displayName": "Peacock",
+  "displayName": "Peacock (Cursor Fix)",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "4.2.5",
+  "version": "4.2.6-cursor-fix.1",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
@@ -352,6 +352,12 @@
           "type": "boolean",
           "default": false,
           "description": "Recommended to remain false. However, when set to true Peacock will not colorize the foreground of any of the affected elements and will only alter the background"
+        },
+        "peacock.cursorFriendlyTitleBar": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled (default), uses a medium gray (#595959) for the title bar foreground color instead of the computed dark/light color. This works around a Cursor IDE CSS bug where titleBar.activeForeground leaks into editor toolbar action icons, making them invisible on dark backgrounds. Disable if you use VS Code (not Cursor) and prefer the original behavior.",
+          "scope": "window"
         },
         "peacock.lightForegroundColor": {
           "type": "string",

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -196,6 +196,10 @@ export function getKeepForegroundColor() {
   return readConfiguration<boolean>(StandardSettings.KeepForegroundColor, false);
 }
 
+export function getCursorFriendlyTitleBar() {
+  return readConfiguration<boolean>(StandardSettings.CursorFriendlyTitleBar, true);
+}
+
 export function getKeepBadgeColor() {
   return readConfiguration<boolean>(StandardSettings.KeepBadgeColor, false);
 }
@@ -314,11 +318,33 @@ function collectTitleBarSettings(backgroundHex: string, keepForegroundColor: boo
       titleBarStyle.inactiveBackgroundHex;
 
     if (!keepForegroundColor) {
-      titleBarSettings[ColorSettings.titleBar_activeForeground] = titleBarStyle.foregroundHex;
+      /**
+       * Cursor IDE has a CSS bug where editor toolbar action icons use
+       * `var(--vscode-titleBar-activeForeground)` instead of
+       * `var(--vscode-icon-foreground)`. This causes the titleBar foreground
+       * color to leak into editor toolbar icons (split editor, more actions, etc.)
+       * which sit on a dark background.
+       *
+       * When `cursorFriendlyTitleBar` is enabled (default: true), we use a
+       * medium gray (#595959) for the titleBar foreground instead of the
+       * computed dark/light foreground. This ensures icons remain visible on
+       * both light Peacock backgrounds AND dark editor toolbars.
+       *
+       * activityBar and statusBar do NOT have this leak, so they keep using
+       * the normal computed foreground (dark on light, light on dark).
+       *
+       * See: https://github.com/johnpapa/vscode-peacock/issues/647
+       */
+      const cursorFriendly = getCursorFriendlyTitleBar();
+      const titleBarForeground = cursorFriendly
+        ? ForegroundColors.CursorTitleBarForeground
+        : titleBarStyle.foregroundHex;
+
+      titleBarSettings[ColorSettings.titleBar_activeForeground] = titleBarForeground;
       titleBarSettings[ColorSettings.titleBar_inactiveForeground] =
         titleBarStyle.inactiveForegroundHex;
       titleBarSettings[ColorSettings.commandCenter_border] = titleBarStyle.inactiveForegroundHex;
-      titleBarSettings[ColorSettings.commandCenter_foreground] = titleBarStyle.foregroundHex;
+      titleBarSettings[ColorSettings.commandCenter_foreground] = titleBarForeground;
     }
   }
   return titleBarSettings;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -14,6 +14,7 @@ export enum StandardSettings {
   SquigglyBeGone = 'squigglyBeGone',
   SurpriseMeFromFavoritesOnly = 'surpriseMeFromFavoritesOnly',
   SurpriseMeOnStartup = 'surpriseMeOnStartup',
+  CursorFriendlyTitleBar = 'cursorFriendlyTitleBar',
 }
 
 export enum AffectedSettings {
@@ -101,6 +102,22 @@ export enum Sections {
 export enum ForegroundColors {
   DarkForeground = '#15202b',
   LightForeground = '#e7e7e7',
+  /**
+   * Medium gray used for titleBar foreground in Cursor IDE.
+   *
+   * Cursor has a CSS bug where editor toolbar action icons use
+   * `var(--vscode-titleBar-activeForeground)` instead of
+   * `var(--vscode-icon-foreground)`. This means the titleBar foreground
+   * color leaks into editor toolbar icons, which sit on a dark background.
+   *
+   * DarkForeground (#15202b) is invisible on dark editor toolbars (1.2:1 contrast).
+   * This medium gray (#595959) is visible on both light Peacock backgrounds
+   * (e.g. 4.48:1 on #fdc579) and dark editor toolbars (1.96:1 on #2d2d30).
+   *
+   * See: https://github.com/johnpapa/vscode-peacock/issues/647
+   * See: https://forum.cursor.com/t/action-icons-use-the-wrong-color/162119
+   */
+  CursorTitleBarForeground = '#595959',
 }
 
 // See WebAIM contrast guidelines: https://webaim.org/articles/contrast/


### PR DESCRIPTION
## Problem

Cursor IDE has a CSS bug where editor toolbar action icons use `var(--vscode-titleBar-activeForeground)` instead of `var(--vscode-icon-foreground)`. Peacock's `titleBar.activeForeground` leaks into editor toolbar icons, making them invisible on dark backgrounds.

When Peacock sets `titleBar.activeForeground` to `#15202b` (default dark foreground), editor toolbar icons become invisible on dark `#2d2d30` background (contrast: 1.2:1).

## Root Cause

Cursor's compiled CSS:
```css
.editor-actions .monaco-action-bar .action-item .action-label {
  color: var(--vscode-titleBar-activeForeground);  /* should be --vscode-icon-foreground */
}
```

VS Code does NOT have this bug. Reference: https://forum.cursor.com/t/action-icons-use-the-wrong-color/162119

## Fix

New setting `peacock.cursorFriendlyTitleBar` (default: `true`):
- When enabled: uses `#595959` for `titleBar.activeForeground` and `commandCenter.foreground`
- `activityBar` and `statusBar` are NOT affected (no CSS leak in Cursor)

## Contrast

| Color | vs Tan #fdc579 | vs Dark #2d2d30 | Verdict |
|-------|----------------|-----------------|---------|
| #15202b (original) | 10.55:1 | 1.20:1 invisible | the bug |
| #595959 (this fix) | 4.48:1 | 1.96:1 visible | compromise |

No single color can achieve WCAG 3:1 on both backgrounds. #595959 is the best compromise — visible on both, though not perfect on either.

## Testing

- TypeScript compiles without errors
- Webpack production build succeeds
- vsce package builds .vsix successfully

Fixes #647