### PR TITLE
feat: add affect active tab background option (#565)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,8 @@ VS Code extension written in TypeScript, bundled with Webpack, published to the 
 | When this changes... | Also update... |
 |---|---|
 | New command added | `package.json` (contributes.commands + menus), `src/models/enums.ts` (Commands enum), `src/commands.ts`, `src/extension.ts` (register), `src/test/`, `docs/guide/`, `docs/changelog/README.md` |
-| New setting added | `package.json` (contributes.configuration), `src/models/enums.ts` (StandardSettings or AffectedSettings enum), `src/configuration/read-configuration.ts`, `src/test/`, `docs/guide/`, `docs/changelog/README.md` |
+| New `StandardSettings` setting added | `package.json` (contributes.configuration), `src/models/enums.ts` (StandardSettings enum), `src/configuration/read-configuration.ts` (add reader), `src/test/`, `docs/guide/`, `docs/changelog/README.md` |
+| New `AffectedSettings` setting added | `package.json` (contributes.configuration), `src/models/enums.ts` (AffectedSettings + ColorSettings enums), `src/models/interfaces.ts` (IPeacockAffectedElementSettings), `src/configuration/read-configuration.ts` (getAffectedElements + collect* function), `src/configuration/update-configuration.ts` (updateAffectedElements), `src/test/suite/affected-elements.test.ts`, `docs/guide/`, `docs/changelog/README.md` |
 | Bug fix | `src/test/` (add a regression test that fails without the fix), `docs/changelog/README.md` |
 | Color application logic | `src/apply-color.ts`, `src/color-library.ts`, related unit tests |
 | Live Share integration | `src/live-share/`, `src/live-share/liveshare-commands.ts`, `package.json` (vsls dependency), related tests, run `npm run test-all` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ npm run test-all                # Run unit + Live Share tests
 
 ## CI/CD
 
+- **CI** (`ci.yml`): Triggered on `pull_request` and `push` to `main` (ignores docs/markdown). Runs lint → build (`test-compile`) → unit tests (`xvfb-run npm run just-test`).
 - **Docs + E2E** (`docs.yml`): Triggered on push to `main` and PRs when `docs/`, `e2e/`, `playwright.config.ts`, or the workflow itself changes. Runs Playwright e2e tests, then deploys `docs/` to GitHub Pages.
 
 ## Adding a New Command
@@ -114,13 +115,26 @@ npm run test-all                # Run unit + Live Share tests
 
 ## Adding a New Setting
 
+### StandardSettings (scalar values, not color tokens)
+
 1. Define the setting in `package.json` under `contributes.configuration.properties` with type, default, and description
-2. Add the setting name to the appropriate enum in `src/models/enums.ts` (`StandardSettings` or `AffectedSettings`)
+2. Add the setting name to `StandardSettings` enum in `src/models/enums.ts`
 3. Add a reader in `src/configuration/read-configuration.ts`
-4. If the setting affects color application, update `src/apply-color.ts`
-5. Add unit tests
-6. Update docs in `docs/guide/`
-7. Update `docs/changelog/README.md`
+4. Add unit tests in `src/test/`
+5. Update docs in `docs/guide/`
+6. Update `docs/changelog/README.md`
+
+### AffectedSettings (toggle whether a VS Code color token is colored)
+
+1. Define the setting in `package.json` under `contributes.configuration.properties` (boolean, default false)
+2. Add to `AffectedSettings` enum in `src/models/enums.ts` — and add the VS Code color token to `ColorSettings` enum
+3. Add the property to `IPeacockAffectedElementSettings` in `src/models/interfaces.ts`
+4. Wire into `getAffectedElements()` in `src/configuration/read-configuration.ts`
+5. Wire into the appropriate `collect*Settings()` function in `src/configuration/read-configuration.ts`
+6. Wire into `updateAffectedElements()` in `src/configuration/update-configuration.ts`
+7. Add unit tests in `src/test/suite/affected-elements.test.ts`
+8. Update docs in `docs/guide/`
+9. Update `docs/changelog/README.md`
 
 ## Common Pitfalls
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -12,6 +12,7 @@ All notable changes to the code will be documented in this file.
 
 ### Features
 
+- Added `peacock.affectTabActiveBackground` setting — optionally colors the active tab's background with the Peacock color. Defaults to `false` to preserve existing behavior ([#565](https://github.com/johnpapa/vscode-peacock/issues/565))
 - Added `peacock.excludedSettings` — an array of VS Code color customization keys (e.g. `statusBar.background`) that Peacock will never modify or delete, protecting your own workspace color settings when applying a color or resetting ([#575](https://github.com/johnpapa/vscode-peacock/issues/575)). Completes and supersedes community PR [#574](https://github.com/johnpapa/vscode-peacock/pull/574). Thanks to [@josh-tepper](https://github.com/josh-tepper)!
 - Added `Peacock: Set SideBar Darkness Level` command — sets the SideBar background to a darker shade of the current Peacock color (Dark, Darker, or Darkest). Useful for maintaining color visibility when the activity bar is hidden ([#560](https://github.com/johnpapa/vscode-peacock/issues/560))
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -55,6 +55,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                          |
 | peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
 | peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
+| peacock.affectTabActiveBackground   | Specifies whether Peacock should affect the active tab's background color. Defaults to false                        |
 | peacock.affectWindowBorder          | Specifies whether Peacock should affect the window border (`window.activeBorder` and `window.inactiveBorder`). Defaults to false. Available on Windows in VS Code 1.104+. |
 | peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)        |
 | peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |

--- a/package.json
+++ b/package.json
@@ -240,6 +240,11 @@
           "default": false,
           "description": "Specifies whether Peacock should affect the window border (window.activeBorder and window.inactiveBorder). Available on Windows in VS Code 1.104+."
         },
+        "peacock.affectTabActiveBackground": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether Peacock should affect the active tab's background color."
+        },
         "peacock.affectTitleBar": {
           "type": "boolean",
           "default": true,

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -248,6 +248,7 @@ export function getAffectedElements() {
     statusAndTitleBorders:
       readConfiguration<boolean>(AffectedSettings.StatusAndTitleBorders) || false,
     tabActiveBorder: readConfiguration<boolean>(AffectedSettings.TabActiveBorder) || false,
+    tabActiveBackground: readConfiguration<boolean>(AffectedSettings.TabActiveBackground) || false,
     windowBorder: readConfiguration<boolean>(AffectedSettings.WindowBorder) || false,
   } as IPeacockAffectedElementSettings;
 }
@@ -448,6 +449,9 @@ function collectAccentBorderSettings(backgroundHex: string) {
   if (isAffectedSettingSelected(AffectedSettings.TabActiveBorder)) {
     accentBorderSettings[ColorSettings.tabActiveBorder] = color;
   }
+  if (isAffectedSettingSelected(AffectedSettings.TabActiveBackground)) {
+    accentBorderSettings[ColorSettings.tabActiveBackground] = color;
+  }
   return accentBorderSettings;
 }
 
@@ -556,6 +560,7 @@ function getAllUserSettings() {
     sideBarBorder: affectSideBarBorder,
     sashHover: affectSashHover,
     tabActiveBorder: affectTabActiveBorder,
+    tabActiveBackground: affectTabActiveBackground,
   } = getAffectedElements();
   return {
     favoriteColors,
@@ -574,6 +579,7 @@ function getAllUserSettings() {
     affectSideBarBorder,
     affectSashHover,
     affectTabActiveBorder,
+    affectTabActiveBackground,
   };
 }
 

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -162,6 +162,7 @@ export async function updateAffectedElements(values: IPeacockAffectedElementSett
   );
   await updateGlobalConfiguration(AffectedSettings.DebuggingStatusBar, values.debuggingStatusBar);
   await updateGlobalConfiguration(AffectedSettings.TabActiveBorder, values.tabActiveBorder);
+  await updateGlobalConfiguration(AffectedSettings.TabActiveBackground, values.tabActiveBackground);
   await updateGlobalConfiguration(AffectedSettings.WindowBorder, values.windowBorder);
 
   return true;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -27,6 +27,7 @@ export enum AffectedSettings {
   StatusBar = 'affectStatusBar',
   StatusAndTitleBorders = 'affectStatusAndTitleBorders',
   TabActiveBorder = 'affectTabActiveBorder',
+  TabActiveBackground = 'affectTabActiveBackground',
   TitleBar = 'affectTitleBar',
   WindowBorder = 'affectWindowBorder',
 }
@@ -86,6 +87,7 @@ export enum ColorSettings {
   statusBarItem_remoteBackground = 'statusBarItem.remoteBackground',
   statusBarItem_remoteForeground = 'statusBarItem.remoteForeground',
   tabActiveBorder = 'tab.activeBorder',
+  tabActiveBackground = 'tab.activeBackground',
   titleBar_activeBackground = 'titleBar.activeBackground',
   titleBar_activeForeground = 'titleBar.activeForeground',
   titleBar_border = 'titleBar.border',

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -42,6 +42,7 @@ export interface IPeacockAffectedElementSettings {
   sashHover: boolean;
   statusAndTitleBorders: boolean;
   tabActiveBorder: boolean;
+  tabActiveBackground: boolean;
   windowBorder: boolean;
 }
 

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -243,6 +243,41 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.window_inactiveBorder]);
     });
 
+    test('tabActiveBackground is colored when enabled', async () => {
+      await updateAffectedElements({
+        tabActiveBackground: true,
+      } as IPeacockAffectedElementSettings);
+
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      assert.equal(config[ColorSettings.tabActiveBackground], peacockGreen);
+    });
+
+    test('tabActiveBackground is not colored when disabled', async () => {
+      await updateAffectedElements({
+        tabActiveBackground: false,
+      } as IPeacockAffectedElementSettings);
+
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      assert.ok(!config[ColorSettings.tabActiveBackground]);
+    });
+
+    test('tabActiveBorder and tabActiveBackground can be enabled independently', async () => {
+      await updateAffectedElements({
+        tabActiveBorder: true,
+        tabActiveBackground: false,
+      } as IPeacockAffectedElementSettings);
+
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      assert.equal(config[ColorSettings.tabActiveBorder], peacockGreen);
+      assert.ok(!config[ColorSettings.tabActiveBackground]);
+    });
+
     suiteTeardown(async () => {
       await updateAffectedElements(allAffectedElements);
     });
@@ -260,6 +295,7 @@ suite('Affected elements', () => {
         sideBarBorder: false,
         sashHover: false,
         tabActiveBorder: false,
+        tabActiveBackground: false,
         windowBorder: false,
       } as IPeacockAffectedElementSettings);
     });
@@ -291,6 +327,7 @@ suite('Affected elements', () => {
       assert.ok(!config[ColorSettings.editorGroupBorder]);
       assert.ok(!config[ColorSettings.sashHover]);
       assert.ok(!config[ColorSettings.tabActiveBorder]);
+      assert.ok(!config[ColorSettings.tabActiveBackground]);
       assert.ok(!config[ColorSettings.window_activeBorder]);
       assert.ok(!config[ColorSettings.window_inactiveBorder]);
     });
@@ -308,6 +345,7 @@ suite('Affected elements', () => {
         debuggingStatusBar: false,
         titleBar: true,
         tabActiveBorder: true,
+        tabActiveBackground: false,
         editorGroupBorder: true,
         panelBorder: true,
         sideBarBorder: true,


### PR DESCRIPTION
## Summary

Adds `peacock.affectTabActiveBackground` (boolean, default `false`) — colors the active editor tab background with the Peacock color when enabled.

Closes #565

## Changes

| File | Change |
|------|--------|
| `package.json` | New `peacock.affectTabActiveBackground` configuration property |
| `src/models/enums.ts` | `AffectedSettings.TabActiveBackground` + `ColorSettings.tabActiveBackground` (`tab.activeBackground`) |
| `src/models/interfaces.ts` | `tabActiveBackground: boolean` added to `IPeacockAffectedElementSettings` |
| `src/configuration/read-configuration.ts` | Wired into `getAffectedElements()`, `collectAccentBorderSettings()`, `getAllUserSettings()` |
| `src/configuration/update-configuration.ts` | Wired into `updateAffectedElements()` |
| `src/test/suite/affected-elements.test.ts` | 3 new tests: enabled/disabled behavior + independence from `tabActiveBorder` |
| `docs/guide/README.md` | New setting documented in settings table |
| `docs/changelog/README.md` | Changelog entry under 4.2.5 Features |
| `AGENTS.md` | Split "Adding a New Setting" into StandardSettings vs AffectedSettings subsections; add `ci.yml` to CI/CD section |
| `.github/copilot-instructions.md` | Maintenance matrix: split "New setting" row into two precise rows with complete file chains |

## Behavior

- Default `false` — no change to existing behavior
- When `true`, `tab.activeBackground` is set to the Peacock color (sourced via the activity bar element style, same as `tab.activeBorder`)
- Completely independent of `affectTabActiveBorder` — both can be toggled separately

## Validation

- ✅ TypeScript compilation clean (`npm run test-compile`)
- ✅ ESLint clean (`npm run lint`)
- ⚠️ Unit tests require VS Code headless — CI will validate via `xvfb-run npm run just-test`