### PR TITLE
fix: prevent status bar disappearance during launch workflows (#572)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -10,6 +10,8 @@ All notable changes to the code will be documented in this file.
 
 ### Fixes
 
+- Fixed status bar disappearing (overridden by VS Code's default orange debugging color) during launch/debug sessions when `affectDebuggingStatusBar` is `false` (the default). Peacock now always writes `statusBar.debuggingBackground` and `statusBar.debuggingForeground` to match the regular status bar whenever the status bar is affected, preventing VS Code from overriding those tokens at debug start. The `affectDebuggingStatusBar` setting still works as before — enabling it produces a complementary distinctive color during debugging ([#572](https://github.com/johnpapa/vscode-peacock/issues/572)).
+
 - Fixed Cursor IDE editor-toolbar action icons becoming invisible when Peacock colors the title bar. Cursor mis-uses `var(--vscode-titleBar-activeForeground)` for editor toolbar action icons (a Cursor CSS bug; VS Code is unaffected), so a dark Peacock title bar foreground made those icons disappear. Peacock now auto-detects Cursor via `vscode.env.appName` and uses a visible mid-gray title bar foreground only there — VS Code behavior is unchanged ([#647](https://github.com/johnpapa/vscode-peacock/issues/647)). Thanks to [@Prontsevich](https://github.com/Prontsevich) for the root-cause analysis.
 
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -47,7 +47,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                            |
 | peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                              |
-| peacock.affectDebuggingStatusBar    | Specifies whether Peacock should affect the status bar while debugging. Defaults to false.                          |
+| peacock.affectDebuggingStatusBar    | Specifies whether Peacock should use a distinct Peacock debugging status bar color while debugging. Defaults to false. When false, Peacock still preserves the normal status bar colors during launch/debug sessions. |
 | peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))               |
 | peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                  |
 | peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                        |

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -379,7 +379,17 @@ function collectStatusBarSettings(backgroundHex: string, keepForegroundColor: bo
         statusBarStyle.foregroundHex;
     }
 
+    // Always set debugging colors to match the regular status bar so VS Code does
+    // not override them with its default debugging color during launch/debug sessions.
+    // (#572: status bar disappears during launch script scenarios)
+    statusBarSettings[ColorSettings.statusBar_debuggingBackground] = statusBarStyle.backgroundHex;
+    if (!keepForegroundColor) {
+      statusBarSettings[ColorSettings.statusBar_debuggingForeground] =
+        statusBarStyle.foregroundHex;
+    }
+
     if (isAffectedSettingSelected(AffectedSettings.DebuggingStatusBar)) {
+      // When the user has opted in, override with a distinctive complementary color.
       const debuggingBackgroundColorHex = getDebuggingBackgroundColorHex(
         statusBarStyle.backgroundHex,
       );

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -384,8 +384,7 @@ function collectStatusBarSettings(backgroundHex: string, keepForegroundColor: bo
     // (#572: status bar disappears during launch script scenarios)
     statusBarSettings[ColorSettings.statusBar_debuggingBackground] = statusBarStyle.backgroundHex;
     if (!keepForegroundColor) {
-      statusBarSettings[ColorSettings.statusBar_debuggingForeground] =
-        statusBarStyle.foregroundHex;
+      statusBarSettings[ColorSettings.statusBar_debuggingForeground] = statusBarStyle.foregroundHex;
     }
 
     if (isAffectedSettingSelected(AffectedSettings.DebuggingStatusBar)) {

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -372,7 +372,11 @@ suite('Affected elements', () => {
       assert.ok(debuggingBorder);
     });
 
-    test('debugging styles are not set when debugging status bar is not affected', async () => {
+    test('debugging background and foreground match status bar when affectDebuggingStatusBar is false', async () => {
+      // Regression test for #572: status bar should not disappear during launch/debug
+      // when affectDebuggingStatusBar is false (the default). Peacock must always write
+      // statusBar.debuggingBackground/Foreground so VS Code cannot override with its default
+      // orange debugging color.
       await updateAffectedElements({
         statusBar: true,
         debuggingStatusBar: false,
@@ -381,12 +385,20 @@ suite('Affected elements', () => {
 
       await executeCommand(Commands.changeColorToPeacockGreen);
       const config = getColorCustomizationConfig();
+      const statusBarBackground = config[ColorSettings.statusBar_background];
+      const statusBarForeground = config[ColorSettings.statusBar_foreground];
       const debuggingBackground = config[ColorSettings.statusBar_debuggingBackground];
       const debuggingForeground = config[ColorSettings.statusBar_debuggingForeground];
       const debuggingBorder = config[ColorSettings.statusBar_debuggingBorder];
-      assert.ok(!debuggingBackground);
-      assert.ok(!debuggingForeground);
-      assert.ok(!debuggingBorder);
+
+      // debugging colors should be set to preserve Peacock's color during debug
+      assert.ok(debuggingBackground, 'debuggingBackground should be set to preserve color during debug');
+      assert.ok(debuggingForeground, 'debuggingForeground should be set to preserve color during debug');
+      // debugging colors should match the regular status bar colors
+      assert.equal(debuggingBackground, statusBarBackground, 'debuggingBackground should match statusBar.background');
+      assert.equal(debuggingForeground, statusBarForeground, 'debuggingForeground should match statusBar.foreground');
+      // border should NOT be set when affectDebuggingStatusBar is false
+      assert.ok(!debuggingBorder, 'debuggingBorder should not be set when affectDebuggingStatusBar is false');
 
       await updateAffectedElements(allAffectedElements);
     });

--- a/src/test/suite/affected-elements.test.ts
+++ b/src/test/suite/affected-elements.test.ts
@@ -392,13 +392,30 @@ suite('Affected elements', () => {
       const debuggingBorder = config[ColorSettings.statusBar_debuggingBorder];
 
       // debugging colors should be set to preserve Peacock's color during debug
-      assert.ok(debuggingBackground, 'debuggingBackground should be set to preserve color during debug');
-      assert.ok(debuggingForeground, 'debuggingForeground should be set to preserve color during debug');
+      assert.ok(
+        debuggingBackground,
+        'debuggingBackground should be set to preserve color during debug',
+      );
+      assert.ok(
+        debuggingForeground,
+        'debuggingForeground should be set to preserve color during debug',
+      );
       // debugging colors should match the regular status bar colors
-      assert.equal(debuggingBackground, statusBarBackground, 'debuggingBackground should match statusBar.background');
-      assert.equal(debuggingForeground, statusBarForeground, 'debuggingForeground should match statusBar.foreground');
+      assert.equal(
+        debuggingBackground,
+        statusBarBackground,
+        'debuggingBackground should match statusBar.background',
+      );
+      assert.equal(
+        debuggingForeground,
+        statusBarForeground,
+        'debuggingForeground should match statusBar.foreground',
+      );
       // border should NOT be set when affectDebuggingStatusBar is false
-      assert.ok(!debuggingBorder, 'debuggingBorder should not be set when affectDebuggingStatusBar is false');
+      assert.ok(
+        !debuggingBorder,
+        'debuggingBorder should not be set when affectDebuggingStatusBar is false',
+      );
 
       await updateAffectedElements(allAffectedElements);
     });

--- a/src/test/suite/cursor-titlebar.test.ts
+++ b/src/test/suite/cursor-titlebar.test.ts
@@ -1,7 +1,13 @@
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import { IPeacockSettings, Commands, ColorSettings, ForegroundColors, peacockGreen } from '../../models';
+import {
+  IPeacockSettings,
+  Commands,
+  ColorSettings,
+  ForegroundColors,
+  peacockGreen,
+} from '../../models';
 import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
 import { executeCommand } from './lib/constants';
 import { getColorCustomizationConfig } from '../../configuration';


### PR DESCRIPTION
## Summary

Fixes the status bar disappearing (overridden by VS Code's default orange debugging color) during launch/debug sessions.

## Root cause

When `affectStatusBar` is `true` but `affectDebuggingStatusBar` is `false` (the default), Peacock never wrote `statusBar.debuggingBackground` or `statusBar.debuggingForeground`. When a debug/launch session started, VS Code applied its own theme-default orange color to those tokens, visually overriding the Peacock-set status bar — making items appear to vanish.

## Fix

In `collectStatusBarSettings`, Peacock now always writes `statusBar.debuggingBackground` and `statusBar.debuggingForeground` to match the regular status bar colors when the status bar is affected. This prevents VS Code from using its defaults for those tokens at debug start.

The `affectDebuggingStatusBar` setting continues to work as intended: enabling it overrides those values with a complementary color for a distinctive visual signal during debugging.

## Test added

- `src/test/suite/affected-elements.test.ts`
  - `debugging background and foreground match status bar when affectDebuggingStatusBar is false`

## Docs updated

- `docs/changelog/README.md` — changelog entry for #572
- `docs/guide/README.md` — clarified that `peacock.affectDebuggingStatusBar` controls the distinct debug accent, while Peacock still preserves normal status bar colors during launch/debug when the setting is `false`

## Validation

- ✅ `npm run lint`
- ✅ `npm run test-compile`
- ⚠️ `npm run just-test` is blocked in this environment because the VS Code extension test runner requires no other running VS Code instance

Closes #572