### PR TITLE
feat: add peacock.excludedSettings to protect user color settings

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,7 @@ All notable changes to the code will be documented in this file.
 
 ### Features
 
+- Added `peacock.excludedSettings` — an array of VS Code color customization keys (e.g. `statusBar.background`) that Peacock will never modify or delete, protecting your own workspace color settings when applying a color or resetting ([#575](https://github.com/johnpapa/vscode-peacock/issues/575)). Completes and supersedes community PR [#574](https://github.com/johnpapa/vscode-peacock/pull/574). Thanks to [@josh-tepper](https://github.com/josh-tepper)!
 - Added `Peacock: Set SideBar Darkness Level` command — sets the SideBar background to a darker shade of the current Peacock color (Dark, Darker, or Darkest). Useful for maintaining color visibility when the activity bar is hidden ([#560](https://github.com/johnpapa/vscode-peacock/issues/560))
 
 ### Docs & Infrastructure

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -119,6 +119,33 @@ Even if you tell Peacock not to "affect" a given element (e.g. `"peacock.affectS
 
 Use `peacock.excludedSettings` to list the color customization keys that Peacock must never modify or delete — not when applying a color, and not when resetting.
 
+#### How to use it
+
+1. Open your workspace `settings.json` (or User settings).
+2. Add `peacock.excludedSettings` and list the color keys you want to protect.
+3. Save. From now on, Peacock leaves those keys alone when you apply a color or reset.
+
+```javascript
+"peacock.excludedSettings": [
+    "statusBar.background",
+    "statusBar.foreground"
+]
+```
+
+#### How it works
+
+Peacock stores its colors in the workspace's `workbench.colorCustomizations`. Two operations normally touch those keys:
+
+- **When you apply a color**, Peacock writes (and overwrites) the color keys for the elements it affects.
+- **When you reset or Peacock cleans up "dirty" state**, Peacock deletes the keys it manages.
+
+Any key you add to `peacock.excludedSettings` is honored in both operations:
+
+- On apply, Peacock **skips** the key, so your own value is never overwritten.
+- On reset, Peacock **filters the key out** before deleting, so your value survives.
+
+In other words, excluded keys are invisible to Peacock, while every other key continues to behave normally.
+
 For example, given this setting:
 
 ```javascript

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -55,6 +55,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                          |
 | peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
 | peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
+| peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)        |
 | peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |
 | peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
 | peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
@@ -111,6 +112,30 @@ You can tell peacock which parts of VS Code will be affected by when you select 
 Peacock also automatically colorizes the Command Center foreground and border to match the title bar when title bar coloring is enabled.
 
 ![affected elements](../assets/affected-settings.png)
+
+### Excluded Settings
+
+Even if you tell Peacock not to "affect" a given element (e.g. `"peacock.affectStatusBar": false`), the related keys in the workspace's `settings.json` can still be deleted when Peacock cleans up or resets "dirty" state. This is a problem if you have your own workspace color customizations that you don't want Peacock to touch.
+
+Use `peacock.excludedSettings` to list the color customization keys that Peacock must never modify or delete — not when applying a color, and not when resetting.
+
+For example, given this setting:
+
+```javascript
+"peacock.excludedSettings": [
+    "statusBar.background",
+    "statusBar.foreground"
+]
+```
+
+Peacock will leave the following values in `workbench.colorCustomizations` untouched, even when you apply a new Peacock color or reset the workspace:
+
+```javascript
+"workbench.colorCustomizations": {
+    "statusBar.background": "#f3dcb6",
+    "statusBar.foreground": "#004572"
+}
+```
 
 ### Element Adjustments
 

--- a/package.json
+++ b/package.json
@@ -246,6 +246,11 @@
           "default": "",
           "description": "The Peacock color that will be applied to workspaces. This should only be set at the workspace level."
         },
+        "peacock.excludedSettings": {
+          "type": "array",
+          "default": [],
+          "description": "An array of VS Code color customization keys (e.g. 'statusBar.background') that Peacock should never modify or delete. This protects your own workspace color settings, even when Peacock applies a color or resets/cleans up."
+        },
         "peacock.elementAdjustments": {
           "type": "object",
           "properties": {

--- a/src/apply-color.ts
+++ b/src/apply-color.ts
@@ -7,6 +7,7 @@ import {
   updateWorkspaceConfiguration,
   updatePeacockColor,
   updatePeacockRemoteColor,
+  getExcludedSettings,
 } from './configuration';
 import { Logger } from './logging';
 import { updateStatusBar } from './statusbar';
@@ -25,7 +26,8 @@ export async function unapplyColors() {
 
   // Overwite color customizations, without the peacock ones.
   // This preserves any extra ones someone might have.
-  const colorCustomizationsWithPeacock = deletePeacocksColorCustomizations();
+  const excludedSettings = getExcludedSettings();
+  const colorCustomizationsWithPeacock = deletePeacocksColorCustomizations(excludedSettings);
   await updateWorkspaceConfiguration(colorCustomizationsWithPeacock);
   updateStatusBar();
 }
@@ -41,20 +43,35 @@ function mergeColorCustomizations(
    */
   const existingColorsClone: ISettingsIndexer = { ...existingColors };
 
+  const excludedSettings = getExcludedSettings();
+
   /**
    * If any existing color settings are not in the set
    * that Peacock manages, remove them.
+   * Excluded settings are never stripped.
    */
   Object.values(ColorSettings)
     .filter(c => !(c in updatedColors))
+    .filter(c => !excludedSettings.includes(c))
     .forEach(c => delete existingColorsClone[c]);
+
+  /**
+   * Filter out any settings that the user has specifically excluded so
+   * Peacock does not overwrite them with new values.
+   */
+  const filteredUpdatedColors: ISettingsIndexer = {};
+  Object.keys(updatedColors).forEach(key => {
+    if (!excludedSettings.includes(key)) {
+      filteredUpdatedColors[key] = updatedColors[key];
+    }
+  });
 
   /**
    * Merge the updated colors on top of the existing colors.
    */
   const mergedCustomizations: ISettingsIndexer = {
     ...existingColorsClone,
-    ...updatedColors,
+    ...filteredUpdatedColors,
   };
 
   return mergedCustomizations;

--- a/src/color-library.ts
+++ b/src/color-library.ts
@@ -152,12 +152,14 @@ export function isValidColorInput(input: string) {
   return isValid;
 }
 
-export function deletePeacocksColorCustomizations() {
+export function deletePeacocksColorCustomizations(excludedSettings: string[] = []) {
   const newColorCustomizations = getColorCustomizationConfigFromWorkspace();
 
-  Object.values(ColorSettings).forEach(setting => {
-    delete newColorCustomizations[setting];
-  });
+  Object.values(ColorSettings)
+    .filter(setting => !excludedSettings.includes(setting))
+    .forEach(setting => {
+      delete newColorCustomizations[setting];
+    });
   return newColorCustomizations;
 }
 

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -255,6 +255,10 @@ export function getElementAdjustments() {
   return adjustments || {};
 }
 
+export function getExcludedSettings() {
+  return readConfiguration<string[]>(StandardSettings.ExcludedSettings, []);
+}
+
 export function getElementAdjustment(elementName: string): ColorAdjustment {
   const elementAdjustments = getElementAdjustments();
   return elementAdjustments[elementName];

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -62,6 +62,10 @@ export async function updateElementAdjustments(adjustments: IPeacockElementAdjus
   return await updateGlobalConfiguration(StandardSettings.ElementAdjustments, adjustments);
 }
 
+export async function updateExcludedSettings(excludedSettings: string[]) {
+  return await updateGlobalConfiguration(StandardSettings.ExcludedSettings, excludedSettings);
+}
+
 export async function updateKeepForegroundColor(value: boolean) {
   return await updateGlobalConfiguration(StandardSettings.KeepForegroundColor, value);
 }

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -5,6 +5,7 @@ export enum StandardSettings {
   DarkenLightenPercentage = 'darkenLightenPercentage',
   DarkForegroundColor = 'darkForegroundColor',
   ElementAdjustments = 'elementAdjustments',
+  ExcludedSettings = 'excludedSettings',
   FavoriteColors = 'favoriteColors',
   KeepBadgeColor = 'keepBadgeColor',
   KeepForegroundColor = 'keepForegroundColor',

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -56,6 +56,7 @@ export interface IPeacockSettings {
   sashHover: boolean;
   affectStatusAndTitleBorders: boolean;
   elementAdjustments: IPeacockElementAdjustments;
+  excludedSettings: string[];
   favoriteColors: IFavoriteColors[];
   keepBadgeColor: boolean;
   keepForegroundColor: boolean;

--- a/src/test/suite/excluded-settings.test.ts
+++ b/src/test/suite/excluded-settings.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert';
+import { Commands, ColorSettings, IPeacockSettings, azureBlue } from '../../models';
+import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
+import { executeCommand } from './lib/constants';
+import { applyColor } from '../../apply-color';
+import {
+  getColorCustomizationConfig,
+  getColorCustomizationConfigFromWorkspace,
+  updateWorkspaceConfiguration,
+  updateExcludedSettings,
+} from '../../configuration';
+
+suite('Excluded Settings Tests', () => {
+  const originalValues = {} as IPeacockSettings;
+
+  // A color the user set themselves that Peacock must never touch.
+  const userValue = '#abcdef';
+  const excludedKey = ColorSettings.statusBar_background;
+  const nonExcludedKey = ColorSettings.statusBar_foreground;
+
+  suiteSetup(async () => await setupTestSuite(originalValues));
+  suiteTeardown(async () => await teardownTestSuite(originalValues));
+  setup(async () => await setupTest());
+
+  async function seedUserColor() {
+    await updateWorkspaceConfiguration({ [excludedKey]: userValue });
+  }
+
+  test('an excluded key is NOT overwritten when a Peacock color is applied', async () => {
+    await updateExcludedSettings([excludedKey]);
+    await seedUserColor();
+
+    await applyColor(azureBlue);
+
+    const config = getColorCustomizationConfig();
+    assert.equal(
+      config[excludedKey],
+      userValue,
+      'Excluded key should keep the user value, not be overwritten by Peacock',
+    );
+    // A non-excluded key should still be colored by Peacock.
+    assert.ok(config[nonExcludedKey], 'Non-excluded key should be applied by Peacock');
+  });
+
+  test('an excluded key is NOT deleted on reset/unapply (removeAllColors)', async () => {
+    await updateExcludedSettings([excludedKey]);
+    await seedUserColor();
+
+    await applyColor(azureBlue);
+    await executeCommand(Commands.removeAllColors);
+
+    const config = getColorCustomizationConfigFromWorkspace();
+    assert.equal(
+      config[excludedKey],
+      userValue,
+      'Excluded key should survive removeAllColors and keep the user value',
+    );
+    // Non-excluded Peacock keys should be cleaned up.
+    assert.ok(
+      !config[ColorSettings.titleBar_activeBackground],
+      'Non-excluded Peacock keys should be removed on reset',
+    );
+  });
+
+  test('non-excluded keys still behave normally (applied and cleaned up)', async () => {
+    await updateExcludedSettings([]);
+
+    await applyColor(azureBlue);
+
+    let config: any = getColorCustomizationConfig();
+    assert.equal(
+      config[excludedKey],
+      azureBlue,
+      'With no exclusions, the status bar background should be the applied Peacock color',
+    );
+
+    await executeCommand(Commands.removeAllColors);
+
+    config = getColorCustomizationConfigFromWorkspace();
+    assert.ok(
+      !config[excludedKey],
+      'With no exclusions, the status bar background should be cleaned up on reset',
+    );
+  });
+});

--- a/src/test/suite/lib/setup-teardown-test-suite.ts
+++ b/src/test/suite/lib/setup-teardown-test-suite.ts
@@ -28,6 +28,8 @@ import {
   updatePeacockRemoteColor,
   getKeepBadgeColor,
   updateKeepBadgeColor,
+  getExcludedSettings,
+  updateExcludedSettings,
 } from '../../../configuration';
 
 import { noopElementAdjustments, executeCommand, allAffectedElements } from './constants';
@@ -54,6 +56,7 @@ export async function setupTestSuite(
   originalValues.showColorInStatusBar = getShowColorInStatusBar();
   originalValues.color = getPeacockColor();
   originalValues.remoteColor = getPeacockRemoteColor();
+  originalValues.excludedSettings = getExcludedSettings();
 
   // Set the test values
   await updateAffectedElements(allAffectedElements);
@@ -68,6 +71,7 @@ export async function setupTestSuite(
   await updateShowColorInStatusBar(true);
   await updatePeacockColor(undefined);
   await updatePeacockRemoteColor(undefined);
+  await updateExcludedSettings([]);
   return extension;
 }
 
@@ -88,4 +92,5 @@ export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await updateShowColorInStatusBar(originalValues.showColorInStatusBar);
   await updatePeacockColor(originalValues.color);
   await updatePeacockRemoteColor(originalValues.remoteColor);
+  await updateExcludedSettings(originalValues.excludedSettings);
 }


### PR DESCRIPTION
> 🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

## Summary

Adds a new `peacock.excludedSettings` setting: an array of VS Code color-customization keys (e.g. `statusBar.background`) that Peacock must **never** modify or delete — not when applying a color, and not when resetting/cleaning up. This protects a user's own workspace color customizations from being overwritten or removed by Peacock.

Completes and supersedes community PR #574 by @josh-tepper, and **closes #575**.

## Example

```jsonc
"peacock.excludedSettings": [
  "statusBar.background",
  "statusBar.foreground"
]
```

With the above, these user values in `workbench.colorCustomizations` are left untouched even when a Peacock color is applied or the workspace is reset:

```jsonc
"workbench.colorCustomizations": {
  "statusBar.background": "#f3dcb6",
  "statusBar.foreground": "#004572"
}
```

## Changes (per the AI-Ready maintenance matrix)

- **`package.json`** — new `peacock.excludedSettings` (`array`, default `[]`) under `contributes.configuration.properties`.
- **`src/models/enums.ts`** — `ExcludedSettings = 'excludedSettings'` in `StandardSettings`.
- **`src/configuration/read-configuration.ts`** — dedicated `getExcludedSettings()` reader.
- **`src/configuration/update-configuration.ts`** — `updateExcludedSettings()` helper (used by tests).
- **`src/color-library.ts`** — `deletePeacocksColorCustomizations(excludedSettings = [])` filters excluded keys before deleting.
- **`src/apply-color.ts`** — `mergeColorCustomizations` uses `getExcludedSettings()` so excluded keys are neither stripped from existing customizations nor overwritten by Peacock; `unapplyColors` passes excluded keys into `deletePeacocksColorCustomizations`.
- **`src/models/interfaces.ts`** + **test setup/teardown** — persist/restore excluded state between tests.
- **`src/test/suite/excluded-settings.test.ts`** — new suite: (a) excluded key not overwritten on apply, (b) excluded key not deleted on reset/`removeAllColors`, (c) non-excluded keys still applied and cleaned up.
- **`docs/guide/README.md`** — new **Excluded Settings** section + settings-table row.
- **`docs/changelog/README.md`** — Features entry crediting @josh-tepper and referencing #575.

## Addressing the #574 review

- **Tests** — added (see new suite).
- **Changelog** — added.
- **Dedicated reader** — added `getExcludedSettings()` rather than inline `readConfiguration` calls.
- **Reset behavior** — excluded keys are intentionally preserved on reset; that is the purpose of the setting (protect the user's own values).
- **Apply behavior** — excluded keys are protected from being overwritten; existing user values are preserved.
- **Scope** — I trialed `scope: "application"` but it caused the extension test host to hang in setup hooks locally, and no other Peacock setting sets an explicit scope, so it now uses the default (`window`) scope for consistency. Happy to revisit if you'd prefer a user-global scope.

## Validation

- ✅ `npm run lint` — passes
- ✅ `npx tsc -p ./` — compiles cleanly
- ⚠️ Full `npm run just-test` could not be run to completion **locally** — the macOS VS Code extension-test host was unstable in this environment (extension host repeatedly went unresponsive / activation was SIGKILLed), which affected all suites, not this change. The unit suite runs on this PR via the `CI` workflow (`xvfb-run -a npm run just-test` on Ubuntu); please rely on that for the authoritative test result.

Co-authored-by: Joshua Tepper &lt;josh-tepper@users.noreply.github.com&gt;