### PR TITLE
feat: add deterministic favorites order for surprise startup (#487)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -7,6 +7,7 @@ All notable changes to the code will be documented in this file.
 ### Features
 
 - Added `peacock.affectWindowBorder` setting — when enabled, Peacock colorizes `window.activeBorder` and `window.inactiveBorder` to match the Peacock color. Window border support is available on Windows in VS Code 1.104+ ([#569](https://github.com/johnpapa/vscode-peacock/issues/569))
+- Added `peacock.surpriseMeInFavoritesOrder` setting — when enabled (with startup surprise + favorites-only), Peacock now cycles favorite colors in deterministic list order across startups instead of choosing favorites randomly ([#487](https://github.com/johnpapa/vscode-peacock/issues/487))
 
 ## 4.2.5
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -66,6 +66,7 @@ Commands can be found in the command palette. Look for commands beginning with "
 | peacock.lightForeground             | override for the light foreground                                                                                   |
 | peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                       |
 | peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color             |
+| peacock.surpriseMeInFavoritesOrder  | When true, and startup surprise uses favorites, Peacock cycles through favorites in list order instead of random   |
 | peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                            |
 | peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                         |
 | peacock.color                       | The Peacock color that will be applied to workspaces                                                                |
@@ -84,6 +85,8 @@ Azure Blue -> #007fff
 ```
 
 Favorite colors require a user-defined name (`name`) and a value ( `value` ), as shown in the example below.
+
+When `peacock.surpriseMeOnStartup` and `peacock.surpriseMeFromFavoritesOnly` are enabled, turning on `peacock.surpriseMeInFavoritesOrder` makes startup surprises reuse favorites in deterministic list order.
 
 ```javascript
   "peacock.favoriteColors": [
@@ -446,6 +449,8 @@ Peacock takes advantage of a memento (a value stored between sessions and not in
 | Name                             | Type   | Description                                                                                                |
 | -------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
 | peacockMementos.favoritesVersion | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings |
+| peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                 |
+| peacockMementos.surpriseMeFavoritesOrderKey | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
 
 ## Try the Code
 

--- a/package.json
+++ b/package.json
@@ -395,6 +395,11 @@
           "default": false,
           "description": "Specifies whether Peacock should choose a random color from the favorites list or a purely random color."
         },
+        "peacock.surpriseMeInFavoritesOrder": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, and Surprise Me on Startup is using favorites, Peacock cycles through favorites in list order instead of choosing randomly."
+        },
         "peacock.surpriseMeOnStartup": {
           "type": "boolean",
           "default": false,

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -235,6 +235,10 @@ export function getSurpriseMeOnStartup() {
   return readConfiguration<boolean>(StandardSettings.SurpriseMeOnStartup, false);
 }
 
+export function getSurpriseMeInFavoritesOrder() {
+  return readConfiguration<boolean>(StandardSettings.SurpriseMeInFavoritesOrder, false);
+}
+
 export function getAffectedElements() {
   return {
     activityBar: readConfiguration<boolean>(AffectedSettings.ActivityBar) || false,
@@ -548,6 +552,7 @@ function getAllUserSettings() {
   const keepBadgeColor = getKeepBadgeColor();
   const keepForegroundColor = getKeepForegroundColor();
   const surpriseMeOnStartup = getSurpriseMeOnStartup();
+  const surpriseMeInFavoritesOrder = getSurpriseMeInFavoritesOrder();
   const darkForegroundColor = getDarkForegroundColor();
   const lightForegroundColor = getLightForegroundColor();
   const {
@@ -568,6 +573,7 @@ function getAllUserSettings() {
     keepBadgeColor,
     keepForegroundColor,
     surpriseMeOnStartup,
+    surpriseMeInFavoritesOrder,
     darkForegroundColor,
     lightForegroundColor,
     affectActivityBar,

--- a/src/configuration/update-configuration.ts
+++ b/src/configuration/update-configuration.ts
@@ -102,6 +102,10 @@ export async function updateSurpriseMeFromFavoritesOnly(value: boolean) {
   return await updateGlobalConfiguration(StandardSettings.SurpriseMeFromFavoritesOnly, value);
 }
 
+export async function updateSurpriseMeInFavoritesOrder(value: boolean) {
+  return await updateGlobalConfiguration(StandardSettings.SurpriseMeInFavoritesOrder, value);
+}
+
 export async function addNewFavoriteColor(name: string, value: string) {
   const { values: favoriteColors } = getFavoriteColors();
   const newFavoriteColors = [...favoriteColors, { name, value }];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,8 @@ import {
 } from './commands';
 import {
   checkIfPeacockSettingsChanged,
+  getSurpriseMeInFavoritesOrder,
+  getSurpriseMeFromFavoritesOnly,
   getSurpriseMeOnStartup,
   writeRecommendedFavoriteColors,
   getEnvironmentAwareColor,
@@ -37,7 +39,14 @@ import { applyColor, updateColorSetting } from './apply-color';
 import { Logger } from './logging';
 import { addLiveShareIntegration } from './live-share';
 import { addRemoteIntegration } from './remote';
-import { saveFavoritesVersionGlobalMemento, getMementos } from './mementos';
+import {
+  saveFavoritesVersionGlobalMemento,
+  getMementos,
+  getSurpriseMeFavoritesOrderIndexGlobalMemento,
+  getSurpriseMeFavoritesOrderKeyGlobalMemento,
+  saveSurpriseMeFavoritesOrderGlobalMemento,
+} from './mementos';
+import type { IFavoriteColors } from './models';
 
 const { commands, workspace } = vscode;
 
@@ -149,9 +158,52 @@ export async function checkSurpriseMeOnStartupLogic() {
       return;
     }
 
-    await changeColorToRandomHandler();
+    const deterministicColorApplied = await applyDeterministicStartupFavoriteColor();
+    if (!deterministicColorApplied) {
+      await changeColorToRandomHandler();
+    }
     const color = getEnvironmentAwareColor();
     const message = `Peacock changed the color to ${color}, because the setting is enabled for ${StandardSettings.SurpriseMeOnStartup}`;
     Logger.info(message);
   }
+}
+
+async function applyDeterministicStartupFavoriteColor() {
+  if (!getSurpriseMeFromFavoritesOnly() || !getSurpriseMeInFavoritesOrder()) {
+    return false;
+  }
+
+  const nextFavorite = await getNextFavoriteColorInOrder();
+  if (!nextFavorite) {
+    return false;
+  }
+
+  await applyColor(nextFavorite.value);
+  await updateColorSetting(nextFavorite.value);
+  return true;
+}
+
+async function getNextFavoriteColorInOrder() {
+  const { values: favoriteColors } = getFavoriteColors();
+  if (!favoriteColors.length) {
+    return undefined;
+  }
+
+  const currentKey = getFavoriteColorsKey(favoriteColors);
+  const previousKey = getSurpriseMeFavoritesOrderKeyGlobalMemento();
+  const previousIndex = getSurpriseMeFavoritesOrderIndexGlobalMemento();
+
+  const resetToStart =
+    previousKey !== currentKey || previousIndex < 0 || previousIndex >= favoriteColors.length;
+  const lastIndex = resetToStart ? -1 : previousIndex;
+  const nextIndex = (lastIndex + 1) % favoriteColors.length;
+
+  await saveSurpriseMeFavoritesOrderGlobalMemento(nextIndex, currentKey);
+  return favoriteColors[nextIndex];
+}
+
+function getFavoriteColorsKey(favoriteColors: IFavoriteColors[]) {
+  return favoriteColors
+    .map(favoriteColor => `${favoriteColor.name}:${favoriteColor.value.toLowerCase()}`)
+    .join('|');
 }

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -7,12 +7,23 @@ export interface IMementoLog {
   value: any;
 }
 
+const fallbackGlobalMementos = new Map<string, any>();
+
+function getGlobalState() {
+  return State.extensionContext?.globalState;
+}
+
 async function saveGlobalMemento(mementoName: string, value: any) {
   if (mementoName) {
     Logger.info(
       `${extensionShortName}: Saving the globalState ${mementoName} memento with value ${value}`,
     );
-    await State.extensionContext.globalState.update(mementoName, value);
+    const globalState = getGlobalState();
+    if (globalState) {
+      await globalState.update(mementoName, value);
+      return;
+    }
+    fallbackGlobalMementos.set(mementoName, value);
   }
 }
 
@@ -26,26 +37,35 @@ export async function saveSurpriseMeFavoritesOrderGlobalMemento(index: number, k
 }
 
 export function getFavoritesVersionGlobalMemento() {
-  return State.extensionContext.globalState.get<string>(peacockMementos.favoritesVersion, '');
+  const globalState = getGlobalState();
+  if (globalState) {
+    return globalState.get<string>(peacockMementos.favoritesVersion, '');
+  }
+  return fallbackGlobalMementos.get(peacockMementos.favoritesVersion) ?? '';
 }
 
 export function getSurpriseMeFavoritesOrderIndexGlobalMemento() {
-  return State.extensionContext.globalState.get<number>(
-    peacockMementos.surpriseMeFavoritesOrderIndex,
-    -1,
-  );
+  const globalState = getGlobalState();
+  if (globalState) {
+    return globalState.get<number>(peacockMementos.surpriseMeFavoritesOrderIndex, -1);
+  }
+  return fallbackGlobalMementos.get(peacockMementos.surpriseMeFavoritesOrderIndex) ?? -1;
 }
 
 export function getSurpriseMeFavoritesOrderKeyGlobalMemento() {
-  return State.extensionContext.globalState.get<string>(
-    peacockMementos.surpriseMeFavoritesOrderKey,
-    '',
-  );
+  const globalState = getGlobalState();
+  if (globalState) {
+    return globalState.get<string>(peacockMementos.surpriseMeFavoritesOrderKey, '');
+  }
+  return fallbackGlobalMementos.get(peacockMementos.surpriseMeFavoritesOrderKey) ?? '';
 }
 
 export async function resetFavoritesVersionMemento() {
   const ec = State.extensionContext;
   if (!ec?.globalState) {
+    fallbackGlobalMementos.delete(peacockMementos.favoritesVersion);
+    fallbackGlobalMementos.delete(peacockMementos.surpriseMeFavoritesOrderIndex);
+    fallbackGlobalMementos.delete(peacockMementos.surpriseMeFavoritesOrderKey);
     Logger.info(
       `${extensionShortName}: Skipping memento reset because extension context is not initialized yet`,
     );
@@ -63,24 +83,23 @@ export async function resetFavoritesVersionMemento() {
 }
 
 export function getMementos() {
-  const ec = State.extensionContext;
   const mementos: IMementoLog[] = [];
 
   // Globals
   mementos.push({
     name: peacockMementos.favoritesVersion,
     type: 'globalState',
-    value: ec.globalState.get(peacockMementos.favoritesVersion),
+    value: getFavoritesVersionGlobalMemento(),
   });
   mementos.push({
     name: peacockMementos.surpriseMeFavoritesOrderIndex,
     type: 'globalState',
-    value: ec.globalState.get(peacockMementos.surpriseMeFavoritesOrderIndex),
+    value: getSurpriseMeFavoritesOrderIndexGlobalMemento(),
   });
   mementos.push({
     name: peacockMementos.surpriseMeFavoritesOrderKey,
     type: 'globalState',
-    value: ec.globalState.get(peacockMementos.surpriseMeFavoritesOrderKey),
+    value: getSurpriseMeFavoritesOrderKeyGlobalMemento(),
   });
 
   return mementos;

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -20,8 +20,27 @@ export async function saveFavoritesVersionGlobalMemento(version: string) {
   saveGlobalMemento(peacockMementos.favoritesVersion, version);
 }
 
+export async function saveSurpriseMeFavoritesOrderGlobalMemento(index: number, key: string) {
+  await saveGlobalMemento(peacockMementos.surpriseMeFavoritesOrderIndex, index);
+  await saveGlobalMemento(peacockMementos.surpriseMeFavoritesOrderKey, key);
+}
+
 export function getFavoritesVersionGlobalMemento() {
   return State.extensionContext.globalState.get<string>(peacockMementos.favoritesVersion, '');
+}
+
+export function getSurpriseMeFavoritesOrderIndexGlobalMemento() {
+  return State.extensionContext.globalState.get<number>(
+    peacockMementos.surpriseMeFavoritesOrderIndex,
+    -1,
+  );
+}
+
+export function getSurpriseMeFavoritesOrderKeyGlobalMemento() {
+  return State.extensionContext.globalState.get<string>(
+    peacockMementos.surpriseMeFavoritesOrderKey,
+    '',
+  );
 }
 
 export async function resetFavoritesVersionMemento() {
@@ -33,6 +52,8 @@ export async function resetFavoritesVersionMemento() {
 
   // Global
   await ec.globalState.update(peacockMementos.favoritesVersion, undefined);
+  await ec.globalState.update(peacockMementos.surpriseMeFavoritesOrderIndex, undefined);
+  await ec.globalState.update(peacockMementos.surpriseMeFavoritesOrderKey, undefined);
 }
 
 export function getMementos() {
@@ -44,6 +65,16 @@ export function getMementos() {
     name: peacockMementos.favoritesVersion,
     type: 'globalState',
     value: ec.globalState.get(peacockMementos.favoritesVersion),
+  });
+  mementos.push({
+    name: peacockMementos.surpriseMeFavoritesOrderIndex,
+    type: 'globalState',
+    value: ec.globalState.get(peacockMementos.surpriseMeFavoritesOrderIndex),
+  });
+  mementos.push({
+    name: peacockMementos.surpriseMeFavoritesOrderKey,
+    type: 'globalState',
+    value: ec.globalState.get(peacockMementos.surpriseMeFavoritesOrderKey),
   });
 
   return mementos;

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -45,6 +45,12 @@ export function getSurpriseMeFavoritesOrderKeyGlobalMemento() {
 
 export async function resetFavoritesVersionMemento() {
   const ec = State.extensionContext;
+  if (!ec?.globalState) {
+    Logger.info(
+      `${extensionShortName}: Skipping memento reset because extension context is not initialized yet`,
+    );
+    return;
+  }
 
   Logger.info(
     `${extensionShortName}: Setting all workspaceState and globalState mementos to undefined`,

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -19,6 +19,8 @@ export const peacockGreen = '#42b883';
 
 export const peacockMementos = {
   favoritesVersion: `${extensionShortName}.favoritesVersion`,
+  surpriseMeFavoritesOrderIndex: `${extensionShortName}.surpriseMeFavoritesOrderIndex`,
+  surpriseMeFavoritesOrderKey: `${extensionShortName}.surpriseMeFavoritesOrderKey`,
 };
 
 export const timeout = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -14,6 +14,7 @@ export enum StandardSettings {
   ShowColorInStatusBar = 'showColorInStatusBar',
   SquigglyBeGone = 'squigglyBeGone',
   SurpriseMeFromFavoritesOnly = 'surpriseMeFromFavoritesOnly',
+  SurpriseMeInFavoritesOrder = 'surpriseMeInFavoritesOrder',
   SurpriseMeOnStartup = 'surpriseMeOnStartup',
 }
 

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -68,6 +68,7 @@ export interface IPeacockSettings {
   showColorInStatusBar: boolean;
   squigglyBeGone: boolean;
   surpriseMeFromFavoritesOnly: boolean;
+  surpriseMeInFavoritesOrder: boolean;
   surpriseMeOnStartup: boolean;
   color: string;
   remoteColor: string;

--- a/src/test/suite/lib/setup-teardown-test-suite.ts
+++ b/src/test/suite/lib/setup-teardown-test-suite.ts
@@ -20,6 +20,8 @@ import {
   updateAffectedElements,
   updateSurpriseMeFromFavoritesOnly,
   getSurpriseMeFromFavoritesOnly,
+  updateSurpriseMeInFavoritesOrder,
+  getSurpriseMeInFavoritesOrder,
   getShowColorInStatusBar,
   updateShowColorInStatusBar,
   getPeacockColor,
@@ -53,6 +55,7 @@ export async function setupTestSuite(
   originalValues.lightForegroundColor = getLightForegroundColor();
   originalValues.keepBadgeColor = getKeepBadgeColor();
   originalValues.surpriseMeFromFavoritesOnly = getSurpriseMeFromFavoritesOnly();
+  originalValues.surpriseMeInFavoritesOrder = getSurpriseMeInFavoritesOrder();
   originalValues.showColorInStatusBar = getShowColorInStatusBar();
   originalValues.color = getPeacockColor();
   originalValues.remoteColor = getPeacockRemoteColor();
@@ -68,6 +71,7 @@ export async function setupTestSuite(
   await updateLightForegroundColor(ForegroundColors.LightForeground);
   await updateKeepBadgeColor(false);
   await updateSurpriseMeFromFavoritesOnly(false);
+  await updateSurpriseMeInFavoritesOrder(false);
   await updateShowColorInStatusBar(true);
   await updatePeacockColor(undefined);
   await updatePeacockRemoteColor(undefined);
@@ -88,6 +92,7 @@ export async function teardownTestSuite(originalValues: IPeacockSettings) {
   await updateLightForegroundColor(originalValues.lightForegroundColor);
   await updateKeepBadgeColor(originalValues.keepBadgeColor);
   await updateSurpriseMeFromFavoritesOnly(originalValues.surpriseMeFromFavoritesOnly);
+  await updateSurpriseMeInFavoritesOrder(originalValues.surpriseMeInFavoritesOrder);
   await updateSurpriseMeOnStartup(originalValues.surpriseMeOnStartup);
   await updateShowColorInStatusBar(originalValues.showColorInStatusBar);
   await updatePeacockColor(originalValues.color);

--- a/src/test/suite/mementos.test.ts
+++ b/src/test/suite/mementos.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import { State } from '../../models';
+import {
+  getFavoritesVersionGlobalMemento,
+  getSurpriseMeFavoritesOrderIndexGlobalMemento,
+  getSurpriseMeFavoritesOrderKeyGlobalMemento,
+  resetFavoritesVersionMemento,
+  saveFavoritesVersionGlobalMemento,
+  saveSurpriseMeFavoritesOrderGlobalMemento,
+} from '../../mementos';
+
+suite('Mementos', () => {
+  test('supports surprise-order mementos before extension context is initialized', async () => {
+    const originalContext = (State as any)._extContext;
+
+    try {
+      (State as any)._extContext = undefined;
+      await resetFavoritesVersionMemento();
+
+      await saveFavoritesVersionGlobalMemento('4.2.6');
+      await saveSurpriseMeFavoritesOrderGlobalMemento(2, 'one:#111|two:#222');
+
+      assert.equal(getFavoritesVersionGlobalMemento(), '4.2.6');
+      assert.equal(getSurpriseMeFavoritesOrderIndexGlobalMemento(), 2);
+      assert.equal(getSurpriseMeFavoritesOrderKeyGlobalMemento(), 'one:#111|two:#222');
+
+      await resetFavoritesVersionMemento();
+
+      assert.equal(getFavoritesVersionGlobalMemento(), '');
+      assert.equal(getSurpriseMeFavoritesOrderIndexGlobalMemento(), -1);
+      assert.equal(getSurpriseMeFavoritesOrderKeyGlobalMemento(), '');
+    } finally {
+      (State as any)._extContext = originalContext;
+    }
+  });
+});

--- a/src/test/suite/surprise-me-on-startup.test.ts
+++ b/src/test/suite/surprise-me-on-startup.test.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import {
   Commands,
+  IFavoriteColors,
   IPeacockSettings,
   IPeacockAffectedElementSettings,
   IElementColors,
@@ -12,9 +14,14 @@ import { executeCommand } from './lib/constants';
 import {
   getOriginalColorsForAllElements,
   updateAffectedElements,
+  updateFavoriteColors,
+  updateSurpriseMeFromFavoritesOnly,
+  updateSurpriseMeInFavoritesOrder,
+  getEnvironmentAwareColor,
   updateSurpriseMeOnStartup,
 } from '../../configuration';
 import { checkSurpriseMeOnStartupLogic } from '../../extension';
+import { resetFavoritesVersionMemento } from '../../mementos';
 
 suite('Surprise me on startup', () => {
   const originalValues = {} as IPeacockSettings;
@@ -25,6 +32,7 @@ suite('Surprise me on startup', () => {
 
   setup(async () => {
     await executeCommand(Commands.resetWorkspaceColors);
+    await resetFavoritesVersionMemento();
     await updateAffectedElements({
       statusBar: true,
       activityBar: true,
@@ -55,6 +63,65 @@ suite('Surprise me on startup', () => {
     });
   });
 
+  suite('when surprise uses favorites', () => {
+    const deterministicFavorites: IFavoriteColors[] = [
+      { name: 'Order One', value: '#111111' },
+      { name: 'Order Two', value: '#222222' },
+      { name: 'Order Three', value: '#333333' },
+    ];
+
+    setup(async () => {
+      await updateSurpriseMeOnStartup(true);
+      await updateSurpriseMeFromFavoritesOnly(true);
+      await updateFavoriteColors(deterministicFavorites);
+    });
+
+    teardown(async () => {
+      await updateSurpriseMeInFavoritesOrder(false);
+      await updateSurpriseMeFromFavoritesOnly(false);
+      await updateSurpriseMeOnStartup(false);
+    });
+
+    test('cycles deterministically when surpriseMeInFavoritesOrder is true', async () => {
+      await updateSurpriseMeInFavoritesOrder(true);
+
+      await assertStartupColor('#111111');
+      await assertStartupColor('#222222');
+      await assertStartupColor('#333333');
+      await assertStartupColor('#111111');
+    });
+
+    test('keeps random behavior when surpriseMeInFavoritesOrder is false', async () => {
+      await updateSurpriseMeInFavoritesOrder(false);
+      const randomStub = sinon.stub(Math, 'random');
+      try {
+        randomStub.onCall(0).returns(0.99);
+        randomStub.onCall(1).returns(0.01);
+
+        await assertStartupColor('#333333');
+        await assertStartupColor('#111111');
+      } finally {
+        randomStub.restore();
+      }
+    });
+
+    test('resets deterministic index when favorites change', async () => {
+      await updateSurpriseMeInFavoritesOrder(true);
+
+      await assertStartupColor('#111111');
+      await assertStartupColor('#222222');
+      await assertStartupColor('#333333');
+
+      await updateFavoriteColors([
+        { name: 'New One', value: '#444444' },
+        { name: 'New Two', value: '#555555' },
+      ]);
+
+      await assertStartupColor('#444444');
+      await assertStartupColor('#555555');
+    });
+  });
+
   async function testColorsBeforeAndAfterInitialConfiguration(assertEquality: EqualityAssertion) {
     const colors1: IElementColors = getOriginalColorsForAllElements();
     await checkSurpriseMeOnStartupLogic();
@@ -62,6 +129,13 @@ suite('Surprise me on startup', () => {
     assertEquality(colors1[ElementNames.activityBar], colors2[ElementNames.activityBar]);
     assertEquality(colors1[ElementNames.statusBar], colors2[ElementNames.statusBar]);
     assertEquality(colors1[ElementNames.titleBar], colors2[ElementNames.titleBar]);
+  }
+
+  async function assertStartupColor(expectedHex: string) {
+    await executeCommand(Commands.resetWorkspaceColors);
+    await checkSurpriseMeOnStartupLogic();
+    const actualColor = getEnvironmentAwareColor();
+    assert.equal(actualColor?.toLowerCase(), expectedHex);
   }
 
   interface EqualityAssertion {


### PR DESCRIPTION
> 🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

## AI-Ready report

### Problem
Users with startup surprise + favorites-only wanted deterministic favorite reuse in stable list order instead of random favorite selection.

### Changes
- Added new opt-in setting `peacock.surpriseMeInFavoritesOrder` (default `false`).
- Wired setting through `StandardSettings`, configuration readers, and test setup update helpers.
- Implemented deterministic startup favorite cycling in `checkSurpriseMeOnStartupLogic` path when all three are enabled:
  - `peacock.surpriseMeOnStartup`
  - `peacock.surpriseMeFromFavoritesOnly`
  - `peacock.surpriseMeInFavoritesOrder`
- Persisted cycle state using global mementos (`index` + favorites-list key) so order continues across windows/sessions.
- Added graceful reset behavior when favorites change or persisted index is out of range.
- Preserved existing random behavior when deterministic mode is off.

### Tests
- Added/updated unit tests for:
  - deterministic ordered cycling across repeated startup triggers
  - random-mode behavior unchanged when deterministic mode is off
  - index reset behavior when favorites list changes
- Validation run in this environment:
  - `npm run lint` ✅
  - `npm run test-compile` ✅
  - `npm run just-test` ❌ (environmental VS Code extension-host test instability/timeouts; failing in suite setup hooks with `Timeout of 7500ms exceeded`, including unchanged suites)

### Docs & changelog
- Updated `docs/guide/README.md` settings table and behavior note.
- Updated mementos section in docs guide.
- Added changelog feature entry in `docs/changelog/README.md`.

### Maintenance-matrix touchpoints
- New `StandardSettings` setting: `package.json`, `src/models/enums.ts`, `src/configuration/read-configuration.ts`, tests, docs, changelog.
- Bug/behavior fix coverage: regression tests + docs/changelog updated.

Closes #487
