### PR TITLE
feat: persist surprise startup selection behavior (#582)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -8,6 +8,7 @@ All notable changes to the code will be documented in this file.
 
 - Added `peacock.affectWindowBorder` setting — when enabled, Peacock colorizes `window.activeBorder` and `window.inactiveBorder` to match the Peacock color. Window border support is available on Windows in VS Code 1.104+ ([#569](https://github.com/johnpapa/vscode-peacock/issues/569))
 - Added `peacock.surpriseMeInFavoritesOrder` setting — when enabled (with startup surprise + favorites-only), Peacock now cycles favorite colors in deterministic list order across startups instead of choosing favorites randomly ([#487](https://github.com/johnpapa/vscode-peacock/issues/487))
+- Startup surprise now persists and restores the last startup-selected color per workspace via mementos, so reopening workspaces (including large worktree setups) keeps expected startup surprise behavior ([#582](https://github.com/johnpapa/vscode-peacock/issues/582))
 
 ## 4.2.5
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -216,6 +216,8 @@ If this setting is `true` and there is no peacock color set, then Peacock will c
 
 Peacock now also remembers the startup-surprise selection per workspace in a global memento. If a workspace has no saved Peacock color at startup, Peacock first restores the last startup-surprise selection for that same workspace before choosing a new random/favorite color.
 
+Example: You open `repo-a` (worktree A) and Peacock startup surprise picks `#333333`. Later you close and reopen worktree A. If worktree A still has no explicit Peacock color in settings, Peacock restores `#333333` for that workspace instead of picking a different color. A different workspace/worktree keeps its own startup-surprise selection.
+
 ### Lighten and Darken
 
 You may like a color but want to lighten or darken it. You can do this through the corresponding [commands](#commands). When you choose one of these commands the current color will be lightened or darkened by the percentage that is in the `darkenLightenPercentage` setting. You may change this setting to be a value between 1 and 10 percent.
@@ -472,6 +474,8 @@ Peacock takes advantage of a memento (a value stored between sessions and not in
 | peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                 |
 | peacockMementos.surpriseMeFavoritesOrderKey | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
 | peacockMementos.surpriseMeStartupSelections | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently |
+
+For example, if `workspaceFolder:file:///repo-a` maps to `#333333`, reopening that same workspace restores `#333333`; `workspaceFolder:file:///repo-b` can map to a different color.
 
 ## Try the Code
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -214,6 +214,8 @@ When set to true Peacock will automatically apply a random color when opening a 
 
 If this setting is `true` and there is no peacock color set, then Peacock will choose a new color. If there is already a color set, Peacock will not choose a random color as this would prevent users from choosing a specific color for some workspaces and surprise in others.
 
+Peacock now also remembers the startup-surprise selection per workspace in a global memento. If a workspace has no saved Peacock color at startup, Peacock first restores the last startup-surprise selection for that same workspace before choosing a new random/favorite color.
+
 ### Lighten and Darken
 
 You may like a color but want to lighten or darken it. You can do this through the corresponding [commands](#commands). When you choose one of these commands the current color will be lightened or darkened by the percentage that is in the `darkenLightenPercentage` setting. You may change this setting to be a value between 1 and 10 percent.
@@ -469,6 +471,7 @@ Peacock takes advantage of a memento (a value stored between sessions and not in
 | peacockMementos.favoritesVersion | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings |
 | peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                 |
 | peacockMementos.surpriseMeFavoritesOrderKey | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
+| peacockMementos.surpriseMeStartupSelections | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently |
 
 ## Try the Code
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,6 +217,10 @@ function getFavoriteColorsKey(favoriteColors: IFavoriteColors[]) {
 }
 
 async function applySavedStartupSelectionForCurrentWorkspace() {
+  if (getSurpriseMeFromFavoritesOnly() && getSurpriseMeInFavoritesOrder()) {
+    return false;
+  }
+
   const workspaceKey = getStartupWorkspaceKey();
   if (!workspaceKey) {
     return false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import {
   getFavoriteColors,
 } from './configuration';
 import { applyColor, updateColorSetting } from './apply-color';
+import { isValidColorInput } from './color-library';
 import { Logger } from './logging';
 import { addLiveShareIntegration } from './live-share';
 import { addRemoteIntegration } from './remote';
@@ -45,6 +46,8 @@ import {
   getSurpriseMeFavoritesOrderIndexGlobalMemento,
   getSurpriseMeFavoritesOrderKeyGlobalMemento,
   saveSurpriseMeFavoritesOrderGlobalMemento,
+  getSurpriseMeStartupSelectionsGlobalMemento,
+  saveSurpriseMeStartupSelectionGlobalMemento,
 } from './mementos';
 import type { IFavoriteColors } from './models';
 
@@ -153,16 +156,21 @@ export async function checkSurpriseMeOnStartupLogic() {
   const peacockColor = getEnvironmentAwareColor();
   if (getSurpriseMeOnStartup()) {
     if (peacockColor) {
+      await saveCurrentWorkspaceStartupSelection(peacockColor);
       const message = `Peacock did not change the color using "surprise me on startup" because the color ${peacockColor} was already set.`;
       Logger.info(message);
       return;
     }
 
-    const deterministicColorApplied = await applyDeterministicStartupFavoriteColor();
-    if (!deterministicColorApplied) {
-      await changeColorToRandomHandler();
+    const restoredSelectionApplied = await applySavedStartupSelectionForCurrentWorkspace();
+    if (!restoredSelectionApplied) {
+      const deterministicColorApplied = await applyDeterministicStartupFavoriteColor();
+      if (!deterministicColorApplied) {
+        await changeColorToRandomHandler();
+      }
     }
     const color = getEnvironmentAwareColor();
+    await saveCurrentWorkspaceStartupSelection(color);
     const message = `Peacock changed the color to ${color}, because the setting is enabled for ${StandardSettings.SurpriseMeOnStartup}`;
     Logger.info(message);
   }
@@ -206,4 +214,51 @@ function getFavoriteColorsKey(favoriteColors: IFavoriteColors[]) {
   return favoriteColors
     .map(favoriteColor => `${favoriteColor.name}:${favoriteColor.value.toLowerCase()}`)
     .join('|');
+}
+
+async function applySavedStartupSelectionForCurrentWorkspace() {
+  const workspaceKey = getStartupWorkspaceKey();
+  if (!workspaceKey) {
+    return false;
+  }
+
+  const startupSelections = getSurpriseMeStartupSelectionsGlobalMemento();
+  const startupSelection = startupSelections[workspaceKey];
+
+  if (!startupSelection || !isValidColorInput(startupSelection)) {
+    return false;
+  }
+
+  await applyColor(startupSelection);
+  await updateColorSetting(startupSelection);
+  return true;
+}
+
+async function saveCurrentWorkspaceStartupSelection(color: string | undefined) {
+  const workspaceKey = getStartupWorkspaceKey();
+  if (!workspaceKey || !color || !isValidColorInput(color)) {
+    return;
+  }
+
+  await saveSurpriseMeStartupSelectionGlobalMemento(workspaceKey, color);
+}
+
+function getStartupWorkspaceKey() {
+  if (workspace.workspaceFile) {
+    return `workspaceFile:${workspace.workspaceFile.toString().toLowerCase()}`;
+  }
+
+  if (!workspace.workspaceFolders?.length) {
+    return '';
+  }
+
+  const sortedWorkspaceFolderUris = workspace.workspaceFolders
+    .map(folder => folder.uri.toString().toLowerCase())
+    .sort();
+
+  if (sortedWorkspaceFolderUris.length === 1) {
+    return `workspaceFolder:${sortedWorkspaceFolderUris[0]}`;
+  }
+
+  return `workspaceFolders:${sortedWorkspaceFolderUris.join('|')}`;
 }

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -1,6 +1,8 @@
 import { peacockMementos, extensionShortName, State } from './models';
 import { Logger } from './logging';
 
+type SurpriseStartupSelections = Record<string, string>;
+
 export interface IMementoLog {
   name: string;
   type: 'workspaceState' | 'globalState';
@@ -36,6 +38,18 @@ export async function saveSurpriseMeFavoritesOrderGlobalMemento(index: number, k
   await saveGlobalMemento(peacockMementos.surpriseMeFavoritesOrderKey, key);
 }
 
+export async function saveSurpriseMeStartupSelectionGlobalMemento(workspaceKey: string, color: string) {
+  if (!workspaceKey || !color) {
+    return;
+  }
+
+  const selections = getSurpriseMeStartupSelectionsGlobalMemento();
+  await saveGlobalMemento(peacockMementos.surpriseMeStartupSelections, {
+    ...selections,
+    [workspaceKey]: color.toLowerCase(),
+  });
+}
+
 export function getFavoritesVersionGlobalMemento() {
   const globalState = getGlobalState();
   if (globalState) {
@@ -60,12 +74,21 @@ export function getSurpriseMeFavoritesOrderKeyGlobalMemento() {
   return fallbackGlobalMementos.get(peacockMementos.surpriseMeFavoritesOrderKey) ?? '';
 }
 
+export function getSurpriseMeStartupSelectionsGlobalMemento(): SurpriseStartupSelections {
+  const globalState = getGlobalState();
+  if (globalState) {
+    return globalState.get<SurpriseStartupSelections>(peacockMementos.surpriseMeStartupSelections, {});
+  }
+  return fallbackGlobalMementos.get(peacockMementos.surpriseMeStartupSelections) ?? {};
+}
+
 export async function resetFavoritesVersionMemento() {
   const ec = State.extensionContext;
   if (!ec?.globalState) {
     fallbackGlobalMementos.delete(peacockMementos.favoritesVersion);
     fallbackGlobalMementos.delete(peacockMementos.surpriseMeFavoritesOrderIndex);
     fallbackGlobalMementos.delete(peacockMementos.surpriseMeFavoritesOrderKey);
+    fallbackGlobalMementos.delete(peacockMementos.surpriseMeStartupSelections);
     Logger.info(
       `${extensionShortName}: Skipping memento reset because extension context is not initialized yet`,
     );
@@ -80,6 +103,7 @@ export async function resetFavoritesVersionMemento() {
   await ec.globalState.update(peacockMementos.favoritesVersion, undefined);
   await ec.globalState.update(peacockMementos.surpriseMeFavoritesOrderIndex, undefined);
   await ec.globalState.update(peacockMementos.surpriseMeFavoritesOrderKey, undefined);
+  await ec.globalState.update(peacockMementos.surpriseMeStartupSelections, undefined);
 }
 
 export function getMementos() {
@@ -100,6 +124,11 @@ export function getMementos() {
     name: peacockMementos.surpriseMeFavoritesOrderKey,
     type: 'globalState',
     value: getSurpriseMeFavoritesOrderKeyGlobalMemento(),
+  });
+  mementos.push({
+    name: peacockMementos.surpriseMeStartupSelections,
+    type: 'globalState',
+    value: getSurpriseMeStartupSelectionsGlobalMemento(),
   });
 
   return mementos;

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -38,7 +38,10 @@ export async function saveSurpriseMeFavoritesOrderGlobalMemento(index: number, k
   await saveGlobalMemento(peacockMementos.surpriseMeFavoritesOrderKey, key);
 }
 
-export async function saveSurpriseMeStartupSelectionGlobalMemento(workspaceKey: string, color: string) {
+export async function saveSurpriseMeStartupSelectionGlobalMemento(
+  workspaceKey: string,
+  color: string,
+) {
   if (!workspaceKey || !color) {
     return;
   }
@@ -77,7 +80,10 @@ export function getSurpriseMeFavoritesOrderKeyGlobalMemento() {
 export function getSurpriseMeStartupSelectionsGlobalMemento(): SurpriseStartupSelections {
   const globalState = getGlobalState();
   if (globalState) {
-    return globalState.get<SurpriseStartupSelections>(peacockMementos.surpriseMeStartupSelections, {});
+    return globalState.get<SurpriseStartupSelections>(
+      peacockMementos.surpriseMeStartupSelections,
+      {},
+    );
   }
   return fallbackGlobalMementos.get(peacockMementos.surpriseMeStartupSelections) ?? {};
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -21,6 +21,7 @@ export const peacockMementos = {
   favoritesVersion: `${extensionShortName}.favoritesVersion`,
   surpriseMeFavoritesOrderIndex: `${extensionShortName}.surpriseMeFavoritesOrderIndex`,
   surpriseMeFavoritesOrderKey: `${extensionShortName}.surpriseMeFavoritesOrderKey`,
+  surpriseMeStartupSelections: `${extensionShortName}.surpriseMeStartupSelections`,
 };
 
 export const timeout = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/test/suite/mementos.test.ts
+++ b/src/test/suite/mementos.test.ts
@@ -4,9 +4,11 @@ import {
   getFavoritesVersionGlobalMemento,
   getSurpriseMeFavoritesOrderIndexGlobalMemento,
   getSurpriseMeFavoritesOrderKeyGlobalMemento,
+  getSurpriseMeStartupSelectionsGlobalMemento,
   resetFavoritesVersionMemento,
   saveFavoritesVersionGlobalMemento,
   saveSurpriseMeFavoritesOrderGlobalMemento,
+  saveSurpriseMeStartupSelectionGlobalMemento,
 } from '../../mementos';
 
 suite('Mementos', () => {
@@ -19,16 +21,21 @@ suite('Mementos', () => {
 
       await saveFavoritesVersionGlobalMemento('4.2.6');
       await saveSurpriseMeFavoritesOrderGlobalMemento(2, 'one:#111|two:#222');
+      await saveSurpriseMeStartupSelectionGlobalMemento('workspaceFolder:file:///repo', '#123456');
 
       assert.equal(getFavoritesVersionGlobalMemento(), '4.2.6');
       assert.equal(getSurpriseMeFavoritesOrderIndexGlobalMemento(), 2);
       assert.equal(getSurpriseMeFavoritesOrderKeyGlobalMemento(), 'one:#111|two:#222');
+      assert.deepEqual(getSurpriseMeStartupSelectionsGlobalMemento(), {
+        'workspaceFolder:file:///repo': '#123456',
+      });
 
       await resetFavoritesVersionMemento();
 
       assert.equal(getFavoritesVersionGlobalMemento(), '');
       assert.equal(getSurpriseMeFavoritesOrderIndexGlobalMemento(), -1);
       assert.equal(getSurpriseMeFavoritesOrderKeyGlobalMemento(), '');
+      assert.deepEqual(getSurpriseMeStartupSelectionsGlobalMemento(), {});
     } finally {
       (State as any)._extContext = originalContext;
     }

--- a/src/test/suite/surprise-me-on-startup.test.ts
+++ b/src/test/suite/surprise-me-on-startup.test.ts
@@ -21,7 +21,10 @@ import {
   updateSurpriseMeOnStartup,
 } from '../../configuration';
 import { checkSurpriseMeOnStartupLogic } from '../../extension';
-import { resetFavoritesVersionMemento } from '../../mementos';
+import {
+  resetFavoritesVersionMemento,
+  saveSurpriseMeStartupSelectionGlobalMemento,
+} from '../../mementos';
 
 suite('Surprise me on startup', () => {
   const originalValues = {} as IPeacockSettings;
@@ -100,6 +103,38 @@ suite('Surprise me on startup', () => {
 
         await assertStartupColor('#333333');
         await assertStartupColor('#111111');
+      } finally {
+        randomStub.restore();
+      }
+    });
+
+    test('restores the last startup surprise selection for the same workspace', async () => {
+      await updateSurpriseMeInFavoritesOrder(false);
+      const randomStub = sinon.stub(Math, 'random');
+      try {
+        randomStub.onCall(0).returns(0.99);
+        randomStub.onCall(1).returns(0.01);
+
+        await assertStartupColor('#333333');
+        await assertStartupColor('#333333');
+
+        assert.equal(randomStub.callCount, 1);
+      } finally {
+        randomStub.restore();
+      }
+    });
+
+    test('does not restore startup selections from other workspaces', async () => {
+      await updateSurpriseMeInFavoritesOrder(false);
+      await saveSurpriseMeStartupSelectionGlobalMemento(
+        'workspaceFolder:file:///different-workspace',
+        '#111111',
+      );
+
+      const randomStub = sinon.stub(Math, 'random');
+      try {
+        randomStub.onCall(0).returns(0.99);
+        await assertStartupColor('#333333');
       } finally {
         randomStub.restore();
       }

--- a/src/test/suite/surprise-me-on-startup.test.ts
+++ b/src/test/suite/surprise-me-on-startup.test.ts
@@ -94,7 +94,7 @@ suite('Surprise me on startup', () => {
       await assertStartupColor('#111111');
     });
 
-    test('keeps random behavior when surpriseMeInFavoritesOrder is false', async () => {
+    test('uses random favorite selection when no startup selection is saved', async () => {
       await updateSurpriseMeInFavoritesOrder(false);
       const randomStub = sinon.stub(Math, 'random');
       try {
@@ -102,6 +102,7 @@ suite('Surprise me on startup', () => {
         randomStub.onCall(1).returns(0.01);
 
         await assertStartupColor('#333333');
+        await resetFavoritesVersionMemento();
         await assertStartupColor('#111111');
       } finally {
         randomStub.restore();


### PR DESCRIPTION
> 🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

Closes #582

## Summary
- Persist startup surprise selections per workspace in global mementos.
- Restore a saved startup surprise selection before generating a new one when `peacock.surpriseMeOnStartup` is enabled and no workspace color is set.
- Keep compatibility with `surpriseMeFromFavoritesOnly` and deterministic favorites-order cycling.

## AI-Ready Report
- **Behavior contract:** startup surprise now behaves as random/favorites-once per workspace, then restores that same startup selection for the same workspace.
- **Implementation:** added `peacockMementos.surpriseMeStartupSelections` and wired restore/save logic into startup activation flow.
- **Regression tests:** added coverage for same-workspace restore and cross-workspace isolation, plus memento persistence/reset coverage.
- **Docs:** updated startup behavior and mementos reference in guide; added changelog entry.

## Validation
- ✅ `npm run lint`
- ✅ `npm run test-compile`
- ⚠️ `npm run just-test` (fails locally when another VS Code instance is open: "Running extension tests from the command line is currently only supported if no other instance of Code is running.")
