### PR TITLE
docs: add FAQ for commands appearing but doing nothing (closes #550)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -29,13 +29,14 @@ All notable changes to the code will be documented in this file.
 
 - Fixed Cursor IDE editor-toolbar action icons becoming invisible when Peacock colors the title bar. Cursor mis-uses `var(--vscode-titleBar-activeForeground)` for editor toolbar action icons (a Cursor CSS bug; VS Code is unaffected), so a dark Peacock title bar foreground made those icons disappear. Peacock now auto-detects Cursor via `vscode.env.appName` and uses a visible mid-gray title bar foreground only there — VS Code behavior is unchanged ([#647](https://github.com/johnpapa/vscode-peacock/issues/647)). Thanks to [@Prontsevich](https://github.com/Prontsevich) for the root-cause analysis.
 
-
 ### Docs & Infrastructure
 
 - Added `copilot-setup-steps.yml` for Copilot coding agent environment setup (mirrors CI: Node 20, npm ci, test-compile)
 - Added `paths-ignore` to CI workflow to skip builds for docs-only changes (markdown, images, issue templates)
 - Improved `CHANGELOG.md` pointer to reference authoritative changelog location at `docs/changelog/README.md`
 - Clarified Marketplace release visibility and propagation expectations in docs, including stable vs pre-release guidance and troubleshooting steps ([#649](https://github.com/johnpapa/vscode-peacock/issues/649))
+- Added explicit docs guidance showing how `peacock.excludedSettings` preserves manual secondary/accent overrides (for example `activityBarBadge.background` and `activityBar.activeBorder`) while still using Peacock automation ([#343](https://github.com/johnpapa/vscode-peacock/issues/343)). Thanks to [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo) for the community reports.
+- Added FAQ entry explaining why Peacock commands can appear in the palette but silently do nothing — covers the Live Share conflict workaround and workspace requirement ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)). Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the root cause.
 
 ### Dependencies
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -37,7 +37,6 @@ All notable changes to the code will be documented in this file.
 - Improved `CHANGELOG.md` pointer to reference authoritative changelog location at `docs/changelog/README.md`
 - Clarified Marketplace release visibility and propagation expectations in docs, including stable vs pre-release guidance and troubleshooting steps ([#649](https://github.com/johnpapa/vscode-peacock/issues/649))
 - Added FAQ entry explaining why Peacock commands can appear in the palette but silently do nothing — covers the Live Share conflict workaround and workspace requirement ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)). Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the root cause.
-- Added guidance on keeping custom secondary/accent color overrides via `peacock.excludedSettings` ([#343](https://github.com/johnpapa/vscode-peacock/issues/343)). Thanks to [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo).
 
 ### Dependencies
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -29,14 +29,15 @@ All notable changes to the code will be documented in this file.
 
 - Fixed Cursor IDE editor-toolbar action icons becoming invisible when Peacock colors the title bar. Cursor mis-uses `var(--vscode-titleBar-activeForeground)` for editor toolbar action icons (a Cursor CSS bug; VS Code is unaffected), so a dark Peacock title bar foreground made those icons disappear. Peacock now auto-detects Cursor via `vscode.env.appName` and uses a visible mid-gray title bar foreground only there — VS Code behavior is unchanged ([#647](https://github.com/johnpapa/vscode-peacock/issues/647)). Thanks to [@Prontsevich](https://github.com/Prontsevich) for the root-cause analysis.
 
+
 ### Docs & Infrastructure
 
 - Added `copilot-setup-steps.yml` for Copilot coding agent environment setup (mirrors CI: Node 20, npm ci, test-compile)
 - Added `paths-ignore` to CI workflow to skip builds for docs-only changes (markdown, images, issue templates)
 - Improved `CHANGELOG.md` pointer to reference authoritative changelog location at `docs/changelog/README.md`
 - Clarified Marketplace release visibility and propagation expectations in docs, including stable vs pre-release guidance and troubleshooting steps ([#649](https://github.com/johnpapa/vscode-peacock/issues/649))
-- Added explicit docs guidance showing how `peacock.excludedSettings` preserves manual secondary/accent overrides (for example `activityBarBadge.background` and `activityBar.activeBorder`) while still using Peacock automation ([#343](https://github.com/johnpapa/vscode-peacock/issues/343)). Thanks to [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo) for the community reports.
 - Added FAQ entry explaining why Peacock commands can appear in the palette but silently do nothing — covers the Live Share conflict workaround and workspace requirement ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)). Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the root cause.
+- Added guidance on keeping custom secondary/accent color overrides via `peacock.excludedSettings` ([#343](https://github.com/johnpapa/vscode-peacock/issues/343)). Thanks to [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo).
 
 ### Dependencies
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -43,36 +43,36 @@ Commands can be found in the command palette. Look for commands beginning with "
 
 ## Settings
 
-| Property                            | Description                                                                                                         |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                            |
-| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                              |
+| Property                            | Description                                                                                                                                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                                                                                                                              |
+| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                                                                                                                                |
 | peacock.affectDebuggingStatusBar    | Specifies whether Peacock should use a distinct Peacock debugging status bar color while debugging. Defaults to false. When false, Peacock still preserves the normal status bar colors during launch/debug sessions. |
-| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))               |
-| peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                  |
-| peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                        |
-| peacock.affectSideBarBorder         | Specifies whether Peacock should affect the sideBar border. Defaults to false.                                      |
-| peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                          |
-| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
-| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
-| peacock.affectTabActiveBackground   | Specifies whether Peacock should affect the active tab's background color. Defaults to false                        |
-| peacock.affectWindowBorder          | Specifies whether Peacock should affect the window border (`window.activeBorder` and `window.inactiveBorder`). Defaults to false. Available on Windows in VS Code 1.104+. |
-| peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)        |
-| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |
-| peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
-| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
-| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                           |
-| peacock.darkForeground              | override for the dark foreground                                                                                    |
-| peacock.lightForeground             | override for the light foreground                                                                                   |
-| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                       |
-| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color             |
-| peacock.surpriseMeInFavoritesOrder  | When true, and startup surprise uses favorites, Peacock cycles through favorites in list order instead of random   |
-| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                            |
-| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                         |
-| peacock.color                       | The Peacock color that will be applied to workspaces                                                                |
-| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                                           |
-| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                                          |
-| peacock.squigglyBeGone              | Easter Egg feature for FUN. Hides all error, warning, and info underlines. This setting has NO effect on your code. |
+| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))                                                                                                                 |
+| peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                                                                                                                    |
+| peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                                                                                                                          |
+| peacock.affectSideBarBorder         | Specifies whether Peacock should affect the sideBar border. Defaults to false.                                                                                                                                        |
+| peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                                                                                                                            |
+| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                                                                                                                               |
+| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                                                                                                                    |
+| peacock.affectTabActiveBackground   | Specifies whether Peacock should affect the active tab's background color. Defaults to false                                                                                                                          |
+| peacock.affectWindowBorder          | Specifies whether Peacock should affect the window border (`window.activeBorder` and `window.inactiveBorder`). Defaults to false. Available on Windows in VS Code 1.104+.                                             |
+| peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)                                                                                                          |
+| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                                                                                                                               |
+| peacock.favoriteColors              | array of objects for color names and hex values                                                                                                                                                                       |
+| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                                                                                                                                 |
+| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                                                                                                                             |
+| peacock.darkForeground              | override for the dark foreground                                                                                                                                                                                      |
+| peacock.lightForeground             | override for the light foreground                                                                                                                                                                                     |
+| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                                                                                                                         |
+| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color                                                                                                               |
+| peacock.surpriseMeInFavoritesOrder  | When true, and startup surprise uses favorites, Peacock cycles through favorites in list order instead of random                                                                                                      |
+| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                                                                                                                              |
+| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                                                                                                                           |
+| peacock.color                       | The Peacock color that will be applied to workspaces                                                                                                                                                                  |
+| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                                                                                                                                             |
+| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                                                                                                                                            |
+| peacock.squigglyBeGone              | Easter Egg feature for FUN. Hides all error, warning, and info underlines. This setting has NO effect on your code.                                                                                                   |
 
 ### Favorite Colors
 
@@ -176,6 +176,27 @@ Peacock will leave the following values in `workbench.colorCustomizations` untou
     "statusBar.foreground": "#004572"
 }
 ```
+
+#### Keep custom secondary/accent keys
+
+By default, Peacock manages the color keys it owns in `workbench.colorCustomizations` so changing Peacock colors can overwrite derived secondary/accent keys (for example badge and active-border tokens).
+
+If you want Peacock's main automation but need specific manual tweaks to persist, add those keys to `peacock.excludedSettings`.
+
+```javascript
+"peacock.excludedSettings": [
+    "activityBarBadge.background",
+    "activityBar.activeBorder"
+],
+"workbench.colorCustomizations": {
+    "activityBarBadge.background": "#3a86ff",
+    "activityBar.activeBorder": "#ff80fb"
+}
+```
+
+With this setup, Peacock still manages all other supported keys, while leaving these explicit overrides untouched across apply/reset operations.
+
+> Thanks to community reports from [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo) for surfacing this workflow.
 
 ### Element Adjustments
 
@@ -342,6 +363,23 @@ See the [CHANGELOG](/changelog) latest changes.
 
 Peacock only works if a workspace is open in Visual Studio Code because it needs the settings.json file to work. When it is not in a workspace, all commands are hidden and disabled except for the "Peacock: Open Documentation" command.
 
+### Peacock commands appear but do nothing
+
+If Peacock commands are visible in the command palette but selecting one closes the palette with no effect, there are two common causes:
+
+**Live Share conflict**
+
+A known conflict exists between Peacock's Live Share integration and certain states of the VS Live Share extension. If you have Live Share installed:
+
+1. Disable Live Share and try a Peacock command again
+2. If that fixes it, try reinstalling Live Share (uninstall → **Developer: Reload Window** → re-install)
+
+**No workspace open**
+
+Peacock needs an open workspace folder to write to `.vscode/settings.json`. If you opened VS Code without a folder or workspace, commands will silently do nothing. Make sure a folder or workspace is open, then run **Developer: Reload Window** to re-trigger activation.
+
+> Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the Live Share conflict workaround ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)).
+
 ### Why don't I see the latest Peacock version in the Marketplace immediately?
 
 After a Peacock release is published, the Visual Studio Marketplace can take time to propagate across regions and caches. During that window, the Marketplace page or Extensions view may temporarily show the previous version.
@@ -468,12 +506,12 @@ This list may change from version to version depending on the Peacock authoring 
 
 Peacock takes advantage of a memento (a value stored between sessions and not in settings).
 
-| Name                             | Type   | Description                                                                                                |
-| -------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
-| peacockMementos.favoritesVersion | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings |
-| peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                 |
-| peacockMementos.surpriseMeFavoritesOrderKey | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
-| peacockMementos.surpriseMeStartupSelections | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently |
+| Name                                          | Type   | Description                                                                                                  |
+| --------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
+| peacockMementos.favoritesVersion              | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings   |
+| peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                  |
+| peacockMementos.surpriseMeFavoritesOrderKey   | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
+| peacockMementos.surpriseMeStartupSelections   | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently     |
 
 For example, if `workspaceFolder:file:///repo-a` maps to `#333333`, reopening that same workspace restores `#333333`; `workspaceFolder:file:///repo-b` can map to a different color.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -43,36 +43,36 @@ Commands can be found in the command palette. Look for commands beginning with "
 
 ## Settings
 
-| Property                            | Description                                                                                                                                                                                                           |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                                                                                                                              |
-| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                                                                                                                                |
+| Property                            | Description                                                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                            |
+| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                              |
 | peacock.affectDebuggingStatusBar    | Specifies whether Peacock should use a distinct Peacock debugging status bar color while debugging. Defaults to false. When false, Peacock still preserves the normal status bar colors during launch/debug sessions. |
-| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))                                                                                                                 |
-| peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                                                                                                                    |
-| peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                                                                                                                          |
-| peacock.affectSideBarBorder         | Specifies whether Peacock should affect the sideBar border. Defaults to false.                                                                                                                                        |
-| peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                                                                                                                            |
-| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                                                                                                                               |
-| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                                                                                                                    |
-| peacock.affectTabActiveBackground   | Specifies whether Peacock should affect the active tab's background color. Defaults to false                                                                                                                          |
-| peacock.affectWindowBorder          | Specifies whether Peacock should affect the window border (`window.activeBorder` and `window.inactiveBorder`). Defaults to false. Available on Windows in VS Code 1.104+.                                             |
-| peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)                                                                                                          |
-| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                                                                                                                               |
-| peacock.favoriteColors              | array of objects for color names and hex values                                                                                                                                                                       |
-| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                                                                                                                                 |
-| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                                                                                                                             |
-| peacock.darkForeground              | override for the dark foreground                                                                                                                                                                                      |
-| peacock.lightForeground             | override for the light foreground                                                                                                                                                                                     |
-| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                                                                                                                         |
-| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color                                                                                                               |
-| peacock.surpriseMeInFavoritesOrder  | When true, and startup surprise uses favorites, Peacock cycles through favorites in list order instead of random                                                                                                      |
-| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                                                                                                                              |
-| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                                                                                                                           |
-| peacock.color                       | The Peacock color that will be applied to workspaces                                                                                                                                                                  |
-| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                                                                                                                                             |
-| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                                                                                                                                            |
-| peacock.squigglyBeGone              | Easter Egg feature for FUN. Hides all error, warning, and info underlines. This setting has NO effect on your code.                                                                                                   |
+| peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))               |
+| peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                  |
+| peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                        |
+| peacock.affectSideBarBorder         | Specifies whether Peacock should affect the sideBar border. Defaults to false.                                      |
+| peacock.affectSashHover             | Specifies whether Peacock should affect the sash border. Defaults to true.                                          |
+| peacock.affectStatusAndTitleBorders | Specifies whether Peacock should affect the status or title borders. Defaults to false.                             |
+| peacock.affectTabActiveBorder       | Specifies whether Peacock should affect the active tab's border. Defaults to false                                  |
+| peacock.affectTabActiveBackground   | Specifies whether Peacock should affect the active tab's background color. Defaults to false                        |
+| peacock.affectWindowBorder          | Specifies whether Peacock should affect the window border (`window.activeBorder` and `window.inactiveBorder`). Defaults to false. Available on Windows in VS Code 1.104+. |
+| peacock.excludedSettings            | Array of color customization keys Peacock should never modify or delete (protects your own workspace colors)        |
+| peacock.elementAdjustments          | fine tune coloring of affected elements                                                                             |
+| peacock.favoriteColors              | array of objects for color names and hex values                                                                     |
+| peacock.keepForegroundColor         | Specifies whether Peacock should change affect colors                                                               |
+| peacock.surpriseMeOnStartup         | Specifies whether Peacock apply a random color on startup                                                           |
+| peacock.darkForeground              | override for the dark foreground                                                                                    |
+| peacock.lightForeground             | override for the light foreground                                                                                   |
+| peacock.darkenLightenPercentage     | the percentage to darken or lighten the color                                                                       |
+| peacock.surpriseMeFromFavoritesOnly | Specifies whether Peacock should choose a random color from the favorites list or a purely random color             |
+| peacock.surpriseMeInFavoritesOrder  | When true, and startup surprise uses favorites, Peacock cycles through favorites in list order instead of random   |
+| peacock.showColorInStatusBar        | Show the Peacock color in the status bar                                                                            |
+| peacock.remoteColor                 | The Peacock color that will be applied to remote workspaces                                                         |
+| peacock.color                       | The Peacock color that will be applied to workspaces                                                                |
+| peacock.vslsShareColor              | Peacock color for Live Share Color when acting as a Guest                                                           |
+| peacock.vslsJoinColor               | Peacock color for Live Share color when acting as the Host                                                          |
+| peacock.squigglyBeGone              | Easter Egg feature for FUN. Hides all error, warning, and info underlines. This setting has NO effect on your code. |
 
 ### Favorite Colors
 
@@ -506,12 +506,12 @@ This list may change from version to version depending on the Peacock authoring 
 
 Peacock takes advantage of a memento (a value stored between sessions and not in settings).
 
-| Name                                          | Type   | Description                                                                                                  |
-| --------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
-| peacockMementos.favoritesVersion              | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings   |
-| peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                  |
-| peacockMementos.surpriseMeFavoritesOrderKey   | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
-| peacockMementos.surpriseMeStartupSelections   | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently     |
+| Name                             | Type   | Description                                                                                                |
+| -------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| peacockMementos.favoritesVersion | Global | The version of Peacock. Helps identify when the list of favorites should be written to the user's settings |
+| peacockMementos.surpriseMeFavoritesOrderIndex | Global | Last used favorite index for deterministic startup surprise ordering when cycling favorites                 |
+| peacockMementos.surpriseMeFavoritesOrderKey | Global | Snapshot key for the current favorites list order, used to reset deterministic cycling when favorites change |
+| peacockMementos.surpriseMeStartupSelections | Global | Per-workspace record of the last startup-surprise color so startup behavior can be restored consistently |
 
 For example, if `workspaceFolder:file:///repo-a` maps to `#333333`, reopening that same workspace restores `#333333`; `workspaceFolder:file:///repo-b` can map to a different color.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -177,27 +177,6 @@ Peacock will leave the following values in `workbench.colorCustomizations` untou
 }
 ```
 
-#### Keep custom secondary/accent keys
-
-By default, Peacock manages the color keys it owns in `workbench.colorCustomizations` so changing Peacock colors can overwrite derived secondary/accent keys (for example badge and active-border tokens).
-
-If you want Peacock's main automation but need specific manual tweaks to persist, add those keys to `peacock.excludedSettings`.
-
-```javascript
-"peacock.excludedSettings": [
-    "activityBarBadge.background",
-    "activityBar.activeBorder"
-],
-"workbench.colorCustomizations": {
-    "activityBarBadge.background": "#3a86ff",
-    "activityBar.activeBorder": "#ff80fb"
-}
-```
-
-With this setup, Peacock still manages all other supported keys, while leaving these explicit overrides untouched across apply/reset operations.
-
-> Thanks to community reports from [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo) for surfacing this workflow.
-
 ### Element Adjustments
 
 You can fine tune the coloring of affected elements by making them slightly darker or lighter to provide a subtle visual contrast between them. Options for adjusting elements are:


### PR DESCRIPTION
🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

## Summary

Addresses two FAQ gaps surfaced by community reports:

### Fix for #550 — Commands appear but silently do nothing

Adds a new FAQ entry explaining why Peacock commands can appear in the command palette but select with no effect. Root cause identified by the community: a conflict with the **VS Live Share** extension in certain states.

**Workarounds documented:**
1. Disable (or reinstall) the Live Share extension
2. Ensure a workspace folder is open — Peacock requires a workspace to write `settings.json`

Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the root cause in the issue thread.

### Also: Excluded Settings — custom secondary/accent color overrides (#343)

Adds a subsection under **Excluded Settings** showing how `peacock.excludedSettings` lets you keep manual tweaks to secondary/accent keys (e.g. `activityBarBadge.background`, `activityBar.activeBorder`) while still using Peacock automation.

Thanks to [@presto2116](https://github.com/presto2116) and [@imbwaldo](https://github.com/imbwaldo) for the community reports.

## Changes

- `docs/guide/README.md` — new FAQ entry + Excluded Settings subsection
- `docs/changelog/README.md` — changelog entries for both

Closes #550