### PR TITLE
Clarify README badge section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ Subtly change the color of your Visual Studio Code workspace. Ideal when you hav
 
 Read the extensive [documentation here](https://johnpapa.github.io/vscode-peacock/) which includes a guide on how to use Peacock and a [changelog](https://johnpapa.github.io/vscode-peacock/#/changelog/)
 
-[Marketplace](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) ·
-[Live Share](https://visualstudio.microsoft.com/services/live-share/?WT.mc_id=academic-0000-jopapa) ·
-[AI Ready](https://github.com/johnpapa/ai-ready) ·
-[MIT License](http://opensource.org/licenses/MIT) ·
-[All Contributors](#contributors) ·
-[CI](https://github.com/johnpapa/vscode-peacock/actions/workflows/ci.yml)
+**Marketplace stats and project links**
+
+[![Version](https://img.shields.io/visual-studio-marketplace/v/johnpapa.vscode-peacock.png?color=2f99fa&style=flat&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/johnpapa.vscode-peacock.png?color=2f99fa&style=flat&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa)
+[![Downloads](https://img.shields.io/visual-studio-marketplace/d/johnpapa.vscode-peacock.png?color=2f99fa&style=flat&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa)
+[![Rating](https://img.shields.io/visual-studio-marketplace/r/johnpapa.vscode-peacock.png?color=2f99fa&style=flat&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa)
+[![Live Share](https://img.shields.io/badge/Live_Share-enabled.png?color=2f99fa&style=flat&logo=visual-studio-code)](https://visualstudio.microsoft.com/services/live-share/?WT.mc_id=academic-0000-jopapa)
+
+[![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen.png?style=flat)](https://github.com/johnpapa/ai-ready)
+[![MIT License](https://img.shields.io/badge/license-MIT-orange.png?color=2f99fa&style=flat)](http://opensource.org/licenses/MIT)
+[![All Contributors](https://img.shields.io/badge/all_contributors-15-blue.png?style=flat)](#contributors)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/johnpapa/vscode-peacock/ci.yml.png?branch=main&label=CI)](https://github.com/johnpapa/vscode-peacock/actions/workflows/ci.yml)
 
 ## Install
 


### PR DESCRIPTION
## Summary
- clarify the purpose of the top README metadata section
- restore visible Marketplace-safe PNG badges for version, installs, downloads, rating, and CI
- keep the README compatible with `vsce package`

## Validation
- `npm run package`
