### PR TITLE
Prepare 4.3.3 recovery release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Read the extensive [documentation here](https://johnpapa.github.io/vscode-peacoc
 
 | Item | Status |
 |---|---|
-| Upcoming release | **4.3.0** |
-| Marketplace version | [4.2.3](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) |
+| Marketplace version | [4.3.3](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) |
 | Installs | [4,362,293](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) |
 | Downloads | [6,553,538](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) |
 | Rating | [4.58/5 from 174 ratings](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa) |

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -8,8 +8,8 @@ All notable changes to the code will be documented in this file.
 
 - Re-published the full 4.3.x feature set as a clean patch release after Marketplace validation checks.
 - Added validation-safe Marketplace badge URLs in `README.md` to avoid blocked SVG badge providers.
-- Confirmed Peacock color customization behavior in VS Code Stable; VS Code Insiders users may need to disable `workbench.experimental.modernUI` until the upstream Insiders regression is fixed.
-- Added a guide FAQ entry documenting the temporary VS Code Insiders `workbench.experimental.modernUI` workaround and upstream tracking issue.
+- Confirmed Peacock color customization behavior when `workbench.experimental.modernUI` is disabled; this workaround applies in Insiders and can also apply in Stable when `modernUI` is manually enabled.
+- Added a guide FAQ entry documenting the temporary `workbench.experimental.modernUI` workaround and upstream tracking issue.
 
 ## 4.3.0
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -9,6 +9,7 @@ All notable changes to the code will be documented in this file.
 - Re-published the full 4.3.x feature set as a clean patch release after Marketplace validation checks.
 - Added validation-safe Marketplace badge URLs in `README.md` to avoid blocked SVG badge providers.
 - Confirmed Peacock color customization behavior in VS Code Stable; VS Code Insiders users may need to disable `workbench.experimental.modernUI` until the upstream Insiders regression is fixed.
+- Added a guide FAQ entry documenting the temporary VS Code Insiders `workbench.experimental.modernUI` workaround and upstream tracking issue.
 
 ## 4.3.0
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,14 @@
 
 All notable changes to the code will be documented in this file.
 
+## 4.3.3
+
+### Release update
+
+- Re-published the full 4.3.x feature set as a clean patch release after Marketplace validation checks.
+- Added validation-safe Marketplace badge URLs in `README.md` to avoid blocked SVG badge providers.
+- Confirmed Peacock color customization behavior in VS Code Stable; VS Code Insiders users may need to disable `workbench.experimental.modernUI` until the upstream Insiders regression is fixed.
+
 ## 4.3.0
 
 > This release consolidates the previously unpublished 4.2.3-4.2.6 changelog drafts into the next Marketplace release after 4.2.2.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -359,6 +359,18 @@ Peacock needs an open workspace folder to write to `.vscode/settings.json`. If y
 
 > Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the Live Share conflict workaround ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)).
 
+### Peacock colors are written but not visually applied (VS Code Insiders)
+
+If Peacock writes `workbench.colorCustomizations` and `peacock.color` but the UI does not change, this can be caused by a current VS Code Insiders regression when `workbench.experimental.modernUI` is enabled.
+
+Temporary workaround:
+
+1. Open Settings and set `"workbench.experimental.modernUI": false`
+2. Run **Developer: Reload Window**
+3. Run a Peacock command again (for example, **Peacock: Surprise Me**)
+
+This is tracked upstream in VS Code: [microsoft/vscode#326445](https://github.com/microsoft/vscode/issues/326445).
+
 ### Why don't I see the latest Peacock version in the Marketplace immediately?
 
 After a Peacock release is published, the Visual Studio Marketplace can take time to propagate across regions and caches. During that window, the Marketplace page or Extensions view may temporarily show the previous version.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -359,9 +359,9 @@ Peacock needs an open workspace folder to write to `.vscode/settings.json`. If y
 
 > Thanks to [@tjeanes](https://github.com/tjeanes), [@ShrimpCryptid](https://github.com/ShrimpCryptid), [@ralfaro17](https://github.com/ralfaro17), and [@diepes](https://github.com/diepes) for identifying the Live Share conflict workaround ([#550](https://github.com/johnpapa/vscode-peacock/issues/550)).
 
-### Peacock colors are written but not visually applied (VS Code Insiders)
+### Peacock colors are written but not visually applied (`modernUI` enabled)
 
-If Peacock writes `workbench.colorCustomizations` and `peacock.color` but the UI does not change, this can be caused by a current VS Code Insiders regression when `workbench.experimental.modernUI` is enabled.
+If Peacock writes `workbench.colorCustomizations` and `peacock.color` but the UI does not change, this can be caused when `workbench.experimental.modernUI` is enabled. We have observed this in Insiders and can also reproduce it in Stable if `modernUI` is turned on.
 
 Temporary workaround:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-peacock",
-  "version": "4.3.0",
+  "version": "4.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-peacock",
-      "version": "4.3.0",
+      "version": "4.3.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@types/tinycolor2": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "4.3.0",
+  "version": "4.3.3",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION
## Summary
- bump extension version metadata to 4.3.3
- add 4.3.3 changelog entry describing recovery publish and Insiders `modernUI` caveat
- add docs FAQ guidance for the temporary Insiders workaround
- update README marketplace status to show 4.3.3 and remove "upcoming release"

## Notes
- 4.3.3 publish was executed as part of this recovery stream
- this PR tracks the repo-side metadata updates for the release