### PR TITLE
chore: exclude e2e screenshots from VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,3 +31,5 @@ docs
 testworkspace
 webpack.config.js
 .prettierrc.js
+# Exclude e2e assets from VSIX
+extension/e2e/**


### PR DESCRIPTION
Exclude extension/e2e/** from VSIX packaging to reduce package size.