### PR TITLE
chore: exclude e2e screenshots from VSIX (additional patterns)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -33,3 +33,7 @@ webpack.config.js
 .prettierrc.js
 # Exclude e2e assets from VSIX
 extension/e2e/**
+
+extension/**/screenshots/**
+
+extension/e2e/screenshots/**


### PR DESCRIPTION
Extend .vscodeignore to ensure screenshot assets are excluded from VSIX packages.