### PR TITLE
chore: exclude e2e from VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -37,3 +37,6 @@ extension/e2e/**
 extension/**/screenshots/**
 
 extension/e2e/screenshots/**
+
+# Exclude e2e directory from VSIX
+e2e/**


### PR DESCRIPTION
Exclude the e2e directory (screenshots/assets) from VSIX packaging to keep package size small.