### PR TITLE
Add latest Marketplace version link at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Peacock for Visual Studio Code
 
+**Latest published version:** [v4.3.4 on the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock&WT.mc_id=academic-0000-jopapa)
+
 ![Peacock Icon](https://raw.githubusercontent.com/johnpapa/vscode-peacock/main/resources/peacock-icon-small.png 'Peacock')
 
 Subtly change the color of your Visual Studio Code workspace. Ideal when you have multiple VS Code instances, use VS Live Share, or use VS Code's Remote features, and you want to quickly identify your editor.


### PR DESCRIPTION
## Summary
Adds a top-of-README line showing the latest published Peacock version with a direct VS Code Marketplace link.

## Change
- Add `Latest published version: v4.3.4` line directly under the README title

## Why
Makes the current published version and install destination immediately visible to readers.