### PR TITLE
fix(cursor): keep readable title bar contrast on dark schemes (#700)

### DIFF
--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as tinycolor from 'tinycolor2';
 import {
   ColorSettings,
   Sections,
@@ -334,9 +335,11 @@ function collectTitleBarSettings(backgroundHex: string, keepForegroundColor: boo
       // Cursor mis-uses titleBar.activeForeground for editor toolbar icons on dark
       // backgrounds; VS Code does not. Only compensate when running in Cursor.
       const isCursor = !!vscode.env.appName && vscode.env.appName.includes('Cursor');
-      const foregroundHex = isCursor
-        ? ForegroundColors.CursorTitleBarForeground
-        : titleBarStyle.foregroundHex;
+      const background = tinycolor(titleBarStyle.backgroundHex);
+      const foregroundHex =
+        isCursor && background.isLight()
+          ? ForegroundColors.CursorTitleBarForeground
+          : titleBarStyle.foregroundHex;
       titleBarSettings[ColorSettings.titleBar_activeForeground] = foregroundHex;
       titleBarSettings[ColorSettings.titleBar_inactiveForeground] =
         titleBarStyle.inactiveForegroundHex;

--- a/src/test/suite/cursor-titlebar.test.ts
+++ b/src/test/suite/cursor-titlebar.test.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as tinycolor from 'tinycolor2';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import {
@@ -7,11 +8,13 @@ import {
   ColorSettings,
   ForegroundColors,
   peacockGreen,
+  ReadabilityRatios,
 } from '../../models';
 import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
 import { executeCommand } from './lib/constants';
 import { getColorCustomizationConfig } from '../../configuration';
 import { getForegroundColorHex } from '../../color-library';
+import { applyColor } from '../../apply-color';
 
 suite('Cursor title bar foreground workaround', () => {
   const originalValues = {} as IPeacockSettings;
@@ -61,5 +64,21 @@ suite('Cursor title bar foreground workaround', () => {
     );
     assert.equal(config[ColorSettings.titleBar_activeForeground], expectedForeground);
     assert.equal(config[ColorSettings.commandCenter_foreground], expectedForeground);
+  });
+
+  test('keeps readable title bar contrast in Cursor on dark schemes', async () => {
+    stubAppName('Cursor');
+
+    await applyColor('#1857a4'); // Mandalorian Blue, a dark favourite
+    const config = getColorCustomizationConfig();
+
+    const bg = config[ColorSettings.titleBar_activeBackground];
+    const fg = config[ColorSettings.titleBar_activeForeground];
+
+    const ratio = tinycolor.readability(bg, fg);
+    assert.ok(
+      ratio >= ReadabilityRatios.Text,
+      `title bar contrast ${ratio.toFixed(2)}:1 is below AA (${ReadabilityRatios.Text}:1)`,
+    );
   });
 });


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Fixes #700</h2>
<p>Title bar text is unreadable in Cursor on dark and mid-tone schemes. On Mandalorian Blue (<code>#1857a4</code>) the text drops to about 1.02:1 against its background, so the file and project name vanish.</p>
<h3>Root cause</h3>
<p>The Cursor branch added in 4.3.0 for #647 forces the title bar foreground to a fixed grey (<code>#595959</code>) for every background. That fixed value only makes sense against a light title bar. On a dark one it has almost no contrast.</p>
<p><code>titleBar.activeForeground</code> drives both the editor toolbar icons that #647 was about and the actual title bar text, so the fixed grey fixed the icons but broke the text.</p>
<h3>The change</h3>
<p>Gate the grey behind <code>background.isLight()</code>. Light Peacock title bars keep the grey, so #647 stays fixed. Dark title bars fall back to the adaptive light foreground (<code>#e7e7e7</code>), which is readable as text and still visible on Cursor's dark toolbar.</p>
<pre><code class="language-ts">const isCursor = !!vscode.env.appName &amp;&amp; vscode.env.appName.includes('Cursor');
const background = tinycolor(titleBarStyle.backgroundHex);
const foregroundHex = isCursor &amp;&amp; background.isLight()
  ? ForegroundColors.CursorTitleBarForeground
  : titleBarStyle.foregroundHex;
</code></pre>
<h3>Contrast (WCAG, background <code>#1857a4</code>)</h3>

Foreground | Contrast | Result
-- | -- | --
Old forced #595959 | 1.02:1 | invisible
New adaptive #e7e7e7 | 5.78:1 | passes AA


<h3>Test</h3>
<p><code>cursor-titlebar.test.ts</code> previously only checked which value was used, never a contrast ratio, so nothing caught this. Added a ratio assertion on a dark scheme:</p>
<pre><code class="language-ts">test('keeps readable title bar contrast in Cursor on dark schemes', async () =&gt; {
  stubAppName('Cursor');

  await applyColor('#1857a4'); // Mandalorian Blue, a dark favourite
  const config = getColorCustomizationConfig();

  const bg = config[ColorSettings.titleBar_activeBackground];
  const fg = config[ColorSettings.titleBar_activeForeground];

  const ratio = tinycolor.readability(bg, fg);
  assert.ok(
    ratio &gt;= ReadabilityRatios.Text,
    `title bar contrast ${ratio.toFixed(2)}:1 is below AA (${ReadabilityRatios.Text}:1)`,
  );
});
</code></pre>
<h3>Verification</h3>
<ul>
<li>The two existing Cursor tests still pass. The light-background case (peacockGreen) keeps the grey, confirming #647 is not regressed.</li>
<li>Manually: launch the Extension Development Host from Cursor, apply Mandalorian Blue, and the title bar text is readable.</li>
</ul>
<p>Fix and test are the only changes. No dependency or config changes.</p></body></html><!--EndFragment-->
</body>
</html>