### PR TITLE
fix: modern UI improvements - backup migration, cursor contrast, and status bar docs

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,20 @@
 
 All notable changes to the code will be documented in this file.
 
+## Unreleased
+
+### Features
+
+- Added automatic migration that backs up existing `workbench.colorCustomizations` on first extension activation, preventing data loss when installing Peacock in workspaces with pre-existing color customizations. Users receive a notification with the option to view backed-up settings ([#687](https://github.com/johnpapa/vscode-peacock/issues/687))
+
+### Fixes
+
+- Fixed title bar text readability on dark color schemes in Cursor IDE. Peacock now gates the mid-gray title bar foreground workaround (#647) behind a `background.isLight()` check, using adaptive light foreground (#e7e7e7) for dark schemes to maintain WCAG AA contrast ratios while preserving the toolbar icon visibility fix on light backgrounds ([#700](https://github.com/johnpapa/vscode-peacock/issues/700))
+
+### Docs & Infrastructure
+
+- Clarified `peacock.affectStatusBar` and `peacock.affectStatusBarDebugging` settings in documentation with dedicated "Status Bar Customization" section, three common scenario examples, and improved setting descriptions to make feature discoverability easier. Closed #704 as this feature was already supported ([#704](https://github.com/johnpapa/vscode-peacock/issues/704))
+
 ## 4.3.3
 
 ### Release update

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -46,8 +46,8 @@ Commands can be found in the command palette. Look for commands beginning with "
 | Property                            | Description                                                                                                                                                                                                           |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | peacock.affectActivityBar           | Specifies whether Peacock should affect the activity bar                                                                                                                                                              |
-| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar                                                                                                                                                                |
-| peacock.affectDebuggingStatusBar    | Specifies whether Peacock should use a distinct Peacock debugging status bar color while debugging. Defaults to false. When false, Peacock still preserves the normal status bar colors during launch/debug sessions. |
+| peacock.affectStatusBar             | Specifies whether Peacock should affect the status bar. Set to `false` to preserve the debugger's orange color or other theme-specific status bar colors.                                                           |
+| peacock.affectStatusBarDebugging    | Specifies whether Peacock should use a distinct Peacock debugging status bar color while debugging. Defaults to false. When false, Peacock still preserves the normal status bar colors during launch/debug sessions. |
 | peacock.affectTitleBar              | Specifies whether Peacock should affect the title bar (see [title bar coloring](#title-bar-coloring))                                                                                                                 |
 | peacock.affectEditorGroupBorder     | Specifies whether Peacock should affect the editorGroup border. Defaults to false.                                                                                                                                    |
 | peacock.affectPanelBorder           | Specifies whether Peacock should affect the panel border. Defaults to false.                                                                                                                                          |
@@ -217,6 +217,41 @@ If this setting is `true` and there is no peacock color set, then Peacock will c
 Peacock now also remembers the startup-surprise selection per workspace in a global memento. If a workspace has no saved Peacock color at startup, Peacock first restores the last startup-surprise selection for that same workspace before choosing a new random/favorite color.
 
 Example: You open `repo-a` (worktree A) and Peacock startup surprise picks `#333333`. Later you close and reopen worktree A. If worktree A still has no explicit Peacock color in settings, Peacock restores `#333333` for that workspace instead of picking a different color. A different workspace/worktree keeps its own startup-surprise selection.
+
+### Status Bar Customization
+
+The status bar is the bar at the bottom of VS Code that shows information like line/column numbers, git branch, and linting status. Peacock provides fine-grained control over status bar coloring:
+
+- **`peacock.affectStatusBar`** (default: `true`): Whether Peacock affects the status bar at all
+  - Set to `false` to completely prevent Peacock from touching the status bar
+  - Useful if you want to preserve theme-specific status bar colors or the debugger's distinctive orange color
+
+- **`peacock.affectStatusBarDebugging`** (default: `false`): Whether Peacock applies its color to the status bar **while debugging**
+  - When `false`, Peacock leaves the status bar untouched during debug sessions (preserves debugger orange)
+  - When `true`, Peacock applies its color even during debugging
+
+#### Common Status Bar Scenarios
+
+**Scenario 1: Never affect the status bar**
+```json
+"peacock.affectStatusBar": false
+```
+Result: Status bar is never colored by Peacock, retaining its theme default and debugger colors.
+
+**Scenario 2: Color the status bar, except during debugging**
+```json
+"peacock.affectStatusBar": true,
+"peacock.affectStatusBarDebugging": false
+```
+Result: Peacock colors the status bar normally, but when you start debugging, the debugger's orange color takes over.
+
+**Scenario 3: Always use Peacock colors, even when debugging**
+```json
+"peacock.affectStatusBar": true,
+"peacock.affectStatusBarDebugging": true
+```
+Result: Peacock's color is applied to the status bar at all times, including during debug sessions.
+
 
 ### Lighten and Darken
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-peacock",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-peacock",
-      "version": "4.3.3",
+      "version": "4.3.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@types/tinycolor2": "^1.4.6",

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,2 +1,3 @@
 export * from './read-configuration';
 export * from './update-configuration';
+export * from './migration';

--- a/src/configuration/migration.ts
+++ b/src/configuration/migration.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { Logger } from '../logging';
+import { extensionShortName, ISettingsIndexer } from '../models';
+import {
+  getColorCustomizationConfigFromWorkspace,
+  getColorCustomizationConfig,
+} from './read-configuration';
+import {
+  getColorCustomizationsBackupDoneMemento,
+  saveColorCustomizationsBackupDoneMemento,
+} from '../mementos';
+
+const ColorCustomizationBackupSection = `${extensionShortName}.colorCustomizationsBackup`;
+
+/**
+ * Backs up any existing workbench.colorCustomizations settings before Peacock applies its colors.
+ * This prevents data loss when users have pre-existing color customizations.
+ *
+ * Related issue: #687 - Installing Peacock blows away existing colorCustomizations
+ */
+export async function backupExistingColorCustomizationsIfNeeded(): Promise<void> {
+  // Only run once per workspace
+  if (getColorCustomizationsBackupDoneMemento()) {
+    return;
+  }
+
+  // Only operate in a workspace
+  if (!vscode.workspace.workspaceFolders) {
+    return;
+  }
+
+  const existingColors = getColorCustomizationConfigFromWorkspace();
+
+  // If no colors exist, nothing to back up
+  if (!existingColors || Object.keys(existingColors).length === 0) {
+    await saveColorCustomizationsBackupDoneMemento();
+    return;
+  }
+
+  // Store the backup in VS Code's settings
+  try {
+    const config = vscode.workspace.getConfiguration();
+    await config.update(
+      ColorCustomizationBackupSection,
+      existingColors,
+      vscode.ConfigurationTarget.Workspace,
+    );
+
+    Logger.info(
+      `${extensionShortName}: Backed up existing workbench.colorCustomizations to ${ColorCustomizationBackupSection}`,
+    );
+
+    // Show an informational message to the user
+    const restoreAction = 'View Backup';
+    const response = await vscode.window.showInformationMessage(
+      `${extensionShortName}: Existing workbench.colorCustomizations have been backed up to workspace settings. You can access them anytime.`,
+      restoreAction,
+    );
+
+    if (response === restoreAction) {
+      await vscode.commands.executeCommand('workbench.action.openSettingsJson');
+    }
+  } catch (error) {
+    Logger.info(
+      `${extensionShortName}: Failed to back up colorCustomizations: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  await saveColorCustomizationsBackupDoneMemento();
+}
+
+/**
+ * Retrieves the backed-up color customizations if they exist
+ */
+export function getBackedUpColorCustomizations(): ISettingsIndexer | undefined {
+  try {
+    const config = getColorCustomizationConfig();
+    const backup = config.get<ISettingsIndexer>(ColorCustomizationBackupSection);
+    return backup && Object.keys(backup).length > 0 ? backup : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as tinycolor from 'tinycolor2';
 import {
   ColorSettings,
   Sections,
@@ -332,9 +333,12 @@ function collectTitleBarSettings(backgroundHex: string, keepForegroundColor: boo
 
     if (!keepForegroundColor) {
       // Cursor mis-uses titleBar.activeForeground for editor toolbar icons on dark
-      // backgrounds; VS Code does not. Only compensate when running in Cursor.
+      // backgrounds; VS Code does not. Only compensate when running in Cursor AND the
+      // background is light. On dark backgrounds in Cursor, a light foreground maintains
+      // better contrast and readability as text.
       const isCursor = !!vscode.env.appName && vscode.env.appName.includes('Cursor');
-      const foregroundHex = isCursor
+      const background = tinycolor(titleBarStyle.backgroundHex);
+      const foregroundHex = isCursor && background.isLight()
         ? ForegroundColors.CursorTitleBarForeground
         : titleBarStyle.foregroundHex;
       titleBarSettings[ColorSettings.titleBar_activeForeground] = foregroundHex;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import {
   inspectColor,
   getCurrentColorBeforeAdjustments,
   getFavoriteColors,
+  backupExistingColorCustomizationsIfNeeded,
 } from './configuration';
 import { applyColor, updateColorSetting } from './apply-color';
 import { isValidColorInput } from './color-library';
@@ -68,6 +69,7 @@ export async function activate(context: vscode.ExtensionContext) {
      * because they may write peacock settings, and it will fail.
      * This entire function will re-run when a workspace is opened.
      */
+    await backupExistingColorCustomizationsIfNeeded();
     await checkSurpriseMeOnStartupLogic();
     await addLiveShareIntegration(State.extensionContext);
     await addRemoteIntegration(State.extensionContext);

--- a/src/mementos.ts
+++ b/src/mementos.ts
@@ -112,6 +112,18 @@ export async function resetFavoritesVersionMemento() {
   await ec.globalState.update(peacockMementos.surpriseMeStartupSelections, undefined);
 }
 
+export function getColorCustomizationsBackupDoneMemento(): boolean {
+  const globalState = getGlobalState();
+  if (globalState) {
+    return globalState.get<boolean>(peacockMementos.colorCustomizationsBackupDone, false);
+  }
+  return fallbackGlobalMementos.get(peacockMementos.colorCustomizationsBackupDone) ?? false;
+}
+
+export async function saveColorCustomizationsBackupDoneMemento(): Promise<void> {
+  return saveGlobalMemento(peacockMementos.colorCustomizationsBackupDone, true);
+}
+
 export function getMementos() {
   const mementos: IMementoLog[] = [];
 

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -22,6 +22,7 @@ export const peacockMementos = {
   surpriseMeFavoritesOrderIndex: `${extensionShortName}.surpriseMeFavoritesOrderIndex`,
   surpriseMeFavoritesOrderKey: `${extensionShortName}.surpriseMeFavoritesOrderKey`,
   surpriseMeStartupSelections: `${extensionShortName}.surpriseMeStartupSelections`,
+  colorCustomizationsBackupDone: `${extensionShortName}.colorCustomizationsBackupDone`,
 };
 
 export const timeout = async (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/test/suite/cursor-titlebar.test.ts
+++ b/src/test/suite/cursor-titlebar.test.ts
@@ -1,12 +1,14 @@
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
+import * as tinycolor from 'tinycolor2';
 import {
   IPeacockSettings,
   Commands,
   ColorSettings,
   ForegroundColors,
   peacockGreen,
+  ReadabilityRatios,
 } from '../../models';
 import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
 import { executeCommand } from './lib/constants';
@@ -32,7 +34,7 @@ suite('Cursor title bar foreground workaround', () => {
     appNameStub = sinon.stub(vscode.env, 'appName').value(name);
   };
 
-  test('uses the Cursor mid-gray foreground when running in Cursor', async () => {
+  test('uses the Cursor mid-gray foreground when running in Cursor on light backgrounds', async () => {
     stubAppName('Cursor');
 
     await executeCommand(Commands.changeColorToPeacockGreen);
@@ -61,5 +63,32 @@ suite('Cursor title bar foreground workaround', () => {
     );
     assert.equal(config[ColorSettings.titleBar_activeForeground], expectedForeground);
     assert.equal(config[ColorSettings.commandCenter_foreground], expectedForeground);
+  });
+
+  test('keeps readable title bar contrast in Cursor on dark schemes', async () => {
+    stubAppName('Cursor');
+
+    // Apply a dark blue color (Mandalorian Blue - #1857a4)
+    const darkColor = '#1857a4';
+    await executeCommand(Commands.enterColor, [darkColor]);
+
+    const config = getColorCustomizationConfig();
+    const bg = config[ColorSettings.titleBar_activeBackground];
+    const fg = config[ColorSettings.titleBar_activeForeground];
+
+    // For dark backgrounds, Cursor should use the adaptive light foreground (#e7e7e7)
+    // instead of the mid-gray CursorTitleBarForeground (#595959)
+    assert.equal(
+      fg,
+      ForegroundColors.LightForeground,
+      'Should use adaptive light foreground on dark backgrounds',
+    );
+
+    // Verify the contrast meets WCAG AA standard (4.5:1 for text)
+    const ratio = tinycolor.readability(bg, fg);
+    assert.ok(
+      ratio >= ReadabilityRatios.Text,
+      `Title bar contrast ${ratio.toFixed(2)}:1 should meet WCAG AA (${ReadabilityRatios.Text}:1)`,
+    );
   });
 });

--- a/src/test/suite/migration.test.ts
+++ b/src/test/suite/migration.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { backupExistingColorCustomizationsIfNeeded, getBackedUpColorCustomizations } from '../configuration/migration';
+import { saveColorCustomizationsBackupDoneMemento } from '../mementos';
+
+suite('Migration Tests', () => {
+  suite('Backup Existing Color Customizations', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+      sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+      sandbox.restore();
+    });
+
+    test('should not run backup if already done', async () => {
+      // Mark backup as already done
+      await saveColorCustomizationsBackupDoneMemento();
+
+      const updateStub = sandbox.stub(vscode.workspace.getConfiguration(), 'update');
+
+      await backupExistingColorCustomizationsIfNeeded();
+
+      assert.strictEqual(updateStub.called, false, 'update should not be called if backup was already done');
+    });
+
+    test('should skip backup if not in a workspace', async () => {
+      sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+      const updateStub = sandbox.stub(vscode.workspace.getConfiguration(), 'update');
+
+      await backupExistingColorCustomizationsIfNeeded();
+
+      assert.strictEqual(updateStub.called, false, 'update should not be called if not in a workspace');
+    });
+
+    test('should handle empty color customizations', async () => {
+      const getConfigStub = sandbox.stub(vscode.workspace, 'getConfiguration');
+      const configMock = {
+        update: sandbox.stub(),
+      };
+      getConfigStub.returns(configMock as any);
+
+      // Mock getColorCustomizationConfigFromWorkspace to return empty
+      const configModule = await import('../configuration/read-configuration');
+      sandbox.stub(configModule, 'getColorCustomizationConfigFromWorkspace').returns({});
+
+      await backupExistingColorCustomizationsIfNeeded();
+
+      assert.strictEqual(
+        configMock.update.called,
+        false,
+        'update should not be called if there are no existing color customizations',
+      );
+    });
+  });
+});

--- a/src/test/suite/migration.test.ts
+++ b/src/test/suite/migration.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { backupExistingColorCustomizationsIfNeeded, getBackedUpColorCustomizations } from '../configuration/migration';
-import { saveColorCustomizationsBackupDoneMemento } from '../mementos';
+import { backupExistingColorCustomizationsIfNeeded } from '../../configuration/migration';
+import { saveColorCustomizationsBackupDoneMemento } from '../../mementos';
 
 suite('Migration Tests', () => {
   suite('Backup Existing Color Customizations', () => {
@@ -44,7 +44,7 @@ suite('Migration Tests', () => {
       getConfigStub.returns(configMock as any);
 
       // Mock getColorCustomizationConfigFromWorkspace to return empty
-      const configModule = await import('../configuration/read-configuration');
+      const configModule = await import('../../configuration/read-configuration');
       sandbox.stub(configModule, 'getColorCustomizationConfigFromWorkspace').returns({});
 
       await backupExistingColorCustomizationsIfNeeded();


### PR DESCRIPTION
## Summary

This PR addresses three UI/UX improvements for better modern IDE compatibility:

### Issue #687: Backup existing colorCustomizations
- Adds automatic migration that backs up existing `workbench.colorCustomizations` on first activation
- Prevents data loss when installing Peacock in a workspace with existing color customizations
- User gets notification with option to view backed-up settings
- Includes unit tests

### Issue #700: Title bar contrast in dark Cursor schemes
- Fixes unreadable title bar text on dark color schemes in Cursor IDE
- Gates the mid-gray foreground workaround (#647) behind `background.isLight()` check
- Light backgrounds: keeps mid-gray #595959 (preserves existing toolbar fix)
- Dark backgrounds: uses adaptive light #e7e7e7 (5.78:1 WCAG AA contrast)
- Includes regression test with Mandalorian Blue (#1857a4) to verify contrast ratios

### Issue #704: Don't affect status bar (documentation)
- Clarified that `peacock.affectStatusBar` setting already provides this feature
- Added dedicated "Status Bar Customization" section in docs with three common scenarios
- Improved setting descriptions to make feature more discoverable
- Closed issue #704 as already-solved

## Changes

- `src/configuration/migration.ts` (new) - Migration module for backup logic
- `src/test/suite/migration.test.ts` (new) - Tests for migration
- `src/configuration/read-configuration.ts` - Cursor foreground fix
- `src/test/suite/cursor-titlebar.test.ts` - Contrast ratio regression test
- `src/models/constants.ts` - New memento constant
- `src/mementos.ts` - Backup tracking helpers
- `src/extension.ts` - Integration of migration
- `src/configuration/index.ts` - Export migration
- `docs/guide/README.md` - Status bar documentation improvements

## Testing

- ✅ Build passes: `npm run webpack` (both extension-node.js and extension-web.js)
- ✅ Linting passes: `npm run lint`
- ✅ Unit tests included for new features
- ✅ Regression test added for title bar contrast

## Related Issues

Closes #687, #700, #704