### PR TITLE
chore(deps-dev): bump eslint from 10.7.0 to 10.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/webpack-env": "^1.18.8",
         "@vitest/coverage-v8": "^0.34.6",
         "@vscode/test-web": "^0.0.81",
-        "eslint": "^10.7.0",
+        "eslint": "^10.9.1",
         "eslint-config-prettier": "^10.1.8",
         "glob": "^7.1.6",
         "husky": "^9.1.7",
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3583,9 +3583,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3595,7 +3595,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -3619,7 +3619,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -8371,9 +8371,9 @@
       }
     },
     "@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "requires": {
         "@eslint/core": "^1.2.1"
@@ -10367,15 +10367,15 @@
       "dev": true
     },
     "eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -10399,7 +10399,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -455,7 +455,7 @@
     "@types/webpack-env": "^1.18.8",
     "@vitest/coverage-v8": "^0.34.6",
     "@vscode/test-web": "^0.0.81",
-    "eslint": "^10.7.0",
+    "eslint": "^10.9.1",
     "eslint-config-prettier": "^10.1.8",
     "glob": "^7.1.6",
     "husky": "^9.1.7",


### PR DESCRIPTION
> 🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

## Why

Closes out the remaining item from dependabot's npm-minor-patch group PR #731 - the other 4 packages in that group were already merged via #733.

## What changed

- `eslint` 10.7.0 -> 10.9.1 (patch release)

## Verification

- `npm ci` - lockfile in sync, clean install
- `npm run lint` - 0 errors, 0 warnings
- `npm run test-compile` (tsc + webpack node/web targets) - clean
- `npm run test:unit` (Vitest) - 142/142 passing
- Host lane relies on CI (sandbox can't launch the VS Code Electron host)
