### PR TITLE
Prepare 4.4.0 release (not published yet)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ vscode-peacock/
 - **Color library:** tinycolor2 — all color manipulation goes through this
 - **VS Live Share:** `vsls` package for Live Share integration
 - **Linting:** ESLint + Prettier (husky pre-commit hook runs Prettier automatically)
-- **Testing:** Mocha (unit tests in `src/test/`) + Playwright (e2e docs tests in `e2e/`)
+- **Testing:** dual-lane — Vitest (fast, pure-logic unit tests in `src/test/unit/`) + Mocha (real VS Code extension host tests in `src/test/suite/`) + Playwright (e2e docs tests in `e2e/`)
 - **Docs:** Docsify (static site in `docs/`, deployed to GitHub Pages)
 
 ## Build & Run
@@ -71,19 +71,26 @@ To run the extension locally, press **F5** in VS Code — this launches the Exte
 ## Testing
 
 ```bash
-npm test                        # Compile + run Mocha unit tests
-npm run just-test               # Run Mocha tests only (skip compile)
+npm test                        # Compile + run Mocha host tests + Vitest unit tests
+npm run test:unit               # Vitest only — fast, pure logic, no VS Code needed
+npm run test:host               # Compile + Mocha host tests + Live Share host tests
+npm run just-test               # Mocha host tests only (skip compile)
 npm run test:e2e                # Run Playwright e2e tests (docs screenshots)
-npm run test:coverage           # Run tests with Istanbul coverage
-npm run test-all                # Run unit + Live Share tests
+npm run test:coverage           # Run both lanes with coverage (host + Vitest)
+npm run test-all                # Run test + Live Share tests
+npm run package:check           # Package the VSIX and verify contents/size (see Release Process)
 ```
 
-**Test structure:**
-- Unit tests live in `src/test/` and use Mocha + Sinon for mocking
+**Test structure — two lanes, pick based on whether the code touches the `vscode` API:**
+
+- **Unit lane** (`src/test/unit/`, Vitest): pure logic with no `vscode` API dependency — color math, data transforms, pick-A-or-B decisions. Runs in ~1s, no VS Code needed. `vscode` itself is mocked (`src/test/unit/mocks/vscode.ts`).
+- **Host lane** (`src/test/suite/`, Mocha + Sinon): anything that touches the real `vscode` API — commands, real config reads/writes, UI prompts. Boots an actual VS Code extension host; slower, but it's the ground truth.
 - E2e tests live in `e2e/` and use Playwright to capture docs screenshots
-- The `testworkspace/` directory is used as a VS Code workspace during tests
+- The `testworkspace/` directory is used as a VS Code workspace during host tests
+- When migrating a host test to the unit lane, only move it if the underlying logic is genuinely pure — extract a pure helper first if needed. Never delete host coverage without an equivalent unit replacement that exercises the same branches.
 
 **Test requirements:**
+
 - Every bug fix must include a regression test that fails without the fix and passes with it
 - Every new feature must include unit tests covering the happy path and relevant edge cases
 - Never merge code that reduces the passing test count
@@ -100,8 +107,20 @@ npm run test-all                # Run unit + Live Share tests
 
 ## CI/CD
 
-- **CI** (`ci.yml`): Triggered on `pull_request` and `push` to `main` (ignores docs/markdown). Runs lint → build (`test-compile`) → unit tests (`xvfb-run npm run just-test`).
+- **CI** (`ci.yml`): Triggered on `pull_request` and `push` to `main` (ignores docs/markdown). Runs, in order: Lint → Build (`test-compile`) → Test (Host) (`xvfb-run npm run just-test`) → Test (Unit) (`npm run test:unit`) → Package contents check (`npm run package:check`).
 - **Docs + E2E** (`docs.yml`): Triggered on push to `main` and PRs when `docs/`, `e2e/`, `playwright.config.ts`, or the workflow itself changes. Runs Playwright e2e tests, then deploys `docs/` to GitHub Pages.
+
+## Release Process
+
+Before publishing a new version, verify all of the following — don't skip steps even if the change feels small:
+
+1. **CI is green on `main`** — check the latest push-triggered run of `ci.yml`, not just the last PR's run.
+2. **Fresh local verification** — `rm -rf node_modules && npm ci`, then `npm run lint`, `npm run test-compile`, `npm run test:unit`, and `npm run package:check` all pass. (Host tests can only be verified via CI in most dev environments — a sandbox without a real VS Code/Electron runtime can't launch the extension host.)
+3. **No open PRs or issues that should block the release** — check for anything still in flight that the release should wait for (e.g., an in-progress dependency-modernization chain).
+4. **`docs/changelog/README.md` is finalized** — rename the `## Unreleased` section to `## X.Y.Z (YYYY-MM-DD)`, add a fresh empty `## Unreleased` heading above it for whatever comes next. Every entry should link the issue/PR it closes. Pick the version bump per semver: a new user-facing feature → minor; fixes/infra only → patch; a removed/renamed command, setting, or default → major.
+5. **`package.json`'s `version` is bumped** — use `npm version X.Y.Z --no-git-tag-version` (updates `package.json` and `package-lock.json` together, no git tag). Version lives solely in `package.json` — there's no other file to sync.
+6. **`README.md`'s "Latest published version" line is left alone until the release is actually live** — it names a real Marketplace link, so updating it early would claim a version is published before it is. Update it (and create the git tag / GitHub Release / `vsce publish`) only as the last step, after the version-bump PR is merged.
+7. **VSIX packaging sanity** — `npm run package:check` catches dev-only file leakage and size regressions automatically (added after `.claude/`, `.husky/`, and stray config files were found shipping in the package unnoticed — see the 4.4.0 changelog entry).
 
 ## Adding a New Command
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,6 +4,8 @@ All notable changes to the code will be documented in this file.
 
 ## Unreleased
 
+## 4.4.0 (2026-09-05)
+
 ### Features
 
 - Added automatic migration that backs up existing `workbench.colorCustomizations` on first extension activation, preventing data loss when installing Peacock in workspaces with pre-existing color customizations. Users receive a notification with the option to view backed-up settings ([#687](https://github.com/johnpapa/vscode-peacock/issues/687))
@@ -19,6 +21,7 @@ All notable changes to the code will be documented in this file.
 ### Docs
 
 - Clarified `peacock.affectStatusBar` and `peacock.affectStatusBarDebugging` settings in documentation with dedicated "Status Bar Customization" section, three common scenario examples, and improved setting descriptions to make feature discoverability easier. Closed #704 as this feature was already supported ([#704](https://github.com/johnpapa/vscode-peacock/issues/704))
+- Synced `AGENTS.md`'s Tech Stack/Testing/CI sections, which still described the pre-#670 single-lane Mocha-only setup — added the Vitest unit lane, the `test:unit`/`package:check` scripts, and the current 5-step CI pipeline. Also added a documented Release Process section (version bump, changelog finalization, verification checklist) ahead of the 4.4.0 release.
 
 ### Infrastructure
 
@@ -33,7 +36,7 @@ All notable changes to the code will be documented in this file.
 - Bumped `@types/node` from `12.12.16` to `20.19.43` ([#724](https://github.com/johnpapa/vscode-peacock/issues/724)) — matches the Node 20 runtime CI already builds/tests against, and is the minimum version modern `vite`/`vitest` require as a peer (`>=20.19.0`). This clears the second blocker in the toolchain chain (after #725's ESLint/TypeScript bump); the last remaining step is a coordinated `vite`/`vitest` major bump.
 - Bumped CI's Node runtime from 20 to 22 (`ci.yml`, `copilot-setup-steps.yml`, `docs.yml`) and `@types/node` from `20.19.43` to `22.20.1` to match, then bumped `vitest`/`@vitest/coverage-v8` from `0.34.6` to `5.0.0` (`vitest@5` requires `@types/node` `^22.0.0 || >=24.0.0` as a peer, which the previous Node 20 baseline couldn't satisfy). Renamed `vitest.config.ts` to `vitest.config.mts` and swapped `__dirname` for `import.meta.dirname` to clear Vitest 5's native-ESM-config warnings; no behavior change, all 142 unit tests still pass ([#724](https://github.com/johnpapa/vscode-peacock/issues/724)).
 - Bumped `eslint` `10.7.0` → `10.9.1` (patch), and `@playwright/test`, `@types/vscode`, `webpack`, `webpack-cli` to their latest compatible versions — routine dependency housekeeping cleared as part of the same modernization pass ([#724](https://github.com/johnpapa/vscode-peacock/issues/724)).
-- **Toolchain modernization complete ([#724](https://github.com/johnpapa/vscode-peacock/issues/724)):** closing out the chain above. Current state: ESLint 10 (flat config), TypeScript 5.9.3, `@types/node` 22.20.1, `vitest`/`@vitest/coverage-v8` 5.0.0, CI on Node 22, and the Dependabot queue is fully clear — every PR blocked on this chain (11 in total) is now either merged in equivalent form or closed with an evidence comment. Two items are intentionally *not* pursued further: TypeScript 7 (no `typescript-eslint` release supports it yet — it hard-caps TS at `<6.1.0`) and `@types/node` 26 (superseded; `22.20.1` is the correct match for the Node 22 runtime CI actually uses). Two small follow-ups remain identified but deferred to their own dedicated PRs: a `glob`/`istanbul-lib-*` major-version bump for the coverage-instrumentation files, and a `prettier` 2 → 3 upgrade (will produce a large reformatting diff, so it deserves review on its own).
+- **Toolchain modernization complete ([#724](https://github.com/johnpapa/vscode-peacock/issues/724)):** closing out the chain above. Current state: ESLint 10 (flat config), TypeScript 5.9.3, `@types/node` 22.20.1, `vitest`/`@vitest/coverage-v8` 5.0.0, CI on Node 22, and the Dependabot queue is fully clear — every PR blocked on this chain (11 in total) is now either merged in equivalent form or closed with an evidence comment. Two items are intentionally _not_ pursued further: TypeScript 7 (no `typescript-eslint` release supports it yet — it hard-caps TS at `<6.1.0`) and `@types/node` 26 (superseded; `22.20.1` is the correct match for the Node 22 runtime CI actually uses). Two small follow-ups remain identified but deferred to their own dedicated PRs: a `glob`/`istanbul-lib-*` major-version bump for the coverage-instrumentation files, and a `prettier` 2 → 3 upgrade (will produce a large reformatting diff, so it deserves review on its own).
 
 ## 4.3.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-peacock",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-peacock",
-      "version": "4.3.4",
+      "version": "4.4.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@types/tinycolor2": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-peacock",
   "displayName": "Peacock",
   "description": "Subtly change the workspace color of your workspace. Ideal when you have multiple VS Code instances and you want to quickly identify which is which.",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "publisher": "johnpapa",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {


### PR DESCRIPTION
# Prepare 4.4.0 release (not published yet)

## Purpose

Release-readiness prep, per a full check requested in chat. Everything here gets the repo one step from publishable — it does **not** publish anything.

## What

- Version bumped `4.3.4` → `4.4.0` via `npm version --no-git-tag-version` (`package.json` + `package-lock.json`). Minor bump: this release has a genuine new feature (#687, automatic `colorCustomizations` backup) alongside fixes/infra, no breaking changes.
- `docs/changelog/README.md` finalized: `## Unreleased` renamed to `## 4.4.0 (2026-09-05)`, fresh empty `## Unreleased` added above for future work.
- `AGENTS.md` synced — it still described the pre-#670 single-lane Mocha-only test setup. Added the Vitest unit lane, `test:unit`/`package:check` scripts, and the current 5-step CI pipeline (Lint → Build → Test Host → Test Unit → Package check).
- Added a **Release Process** section to `AGENTS.md` documenting the exact checklist this PR followed, so it's repeatable for the next release without re-deriving it.

## Deliberately NOT done here

- `README.md`'s "Latest published version" line — still correctly says 4.3.4. Updating it now would claim a version is on the Marketplace before it actually is.
- No git tag, no GitHub Release, no `vsce publish`.

Those are the actual publish step, to be done after this merges, whenever you're ready to pull the trigger.

## Verification

- Fresh `npm ci` — lockfile in sync.
- `npm run lint` — 0 errors.
- `npm run test-compile` — clean (both Node/Web webpack targets).
- `npm run test:unit` — 142/142 passing.
- `npm run package:check` — 244.36 KB, contents clean.
- Host tests: confirmed via CI on `main`'s latest push (192 passing, 1 pending) — can't launch a real VS Code extension host in this sandbox.
- Confirmed zero open PRs and the dependency-modernization tracking issue (#724) is closed — nothing in flight that should block this.

## Checklist of changes included

- [x] CHANGELOG updated
- [ ] README updated — deliberately not (see above)
- [ ] Tests updated/added — N/A, docs/version only
- [x] Prettier formatting
- [ ] console.log removed — N/A
- [ ] Dead code removed — N/A
- [ ] Unnecessary comments removed — N/A
- [ ] Images updated — N/A
- [x] Version updated everywhere — `package.json` + `package-lock.json`

---

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuLeTeddevHj2CBBQVDFdR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuLeTeddevHj2CBBQVDFdR)_