### PR TITLE
Fix 4.4.0 release date

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,7 +4,7 @@ All notable changes to the code will be documented in this file.
 
 ## Unreleased
 
-## 4.4.0 (2026-09-05)
+## 4.4.0 (2026-09-07)
 
 ### Features
 


### PR DESCRIPTION
Corrects the changelog's 4.4.0 header date from 2026-09-05 to 2026-09-07, the actual date this release is being tagged.