### PR TITLE
Fix gray active activity bar icon under Modern UI (#652)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,6 +4,10 @@ All notable changes to the code will be documented in this file.
 
 ## Unreleased
 
+### Fixes
+
+- Fixed the currently-selected activity bar icon rendering VS Code's default gray instead of Peacock's colorized foreground under Modern UI's "activity bar on top" layout (and, more subtly, in the classic side layout too). VS Code's `activityBar.activeBorder` and `activityBarTop.activeBorder` tokens both default to the theme's own foreground color rather than any `workbench.colorCustomizations` override, so leaving them unset could mismatch the rest of the Peacock-colorized icons. Peacock now sets both explicitly to match the computed foreground ([#652](https://github.com/johnpapa/vscode-peacock/issues/652))
+
 ## 4.4.0 (2026-09-07)
 
 ### Features

--- a/src/configuration/read-configuration.ts
+++ b/src/configuration/read-configuration.ts
@@ -375,10 +375,18 @@ function collectActivityBarSettings(
       activityBarSettings[ColorSettings.activityBar_foreground] = activityBarStyle.foregroundHex;
       activityBarSettings[ColorSettings.activityBar_inactiveForeground] =
         activityBarStyle.inactiveForegroundHex;
+      // VS Code defaults activityBar.activeBorder / activityBarTop.activeBorder to the
+      // theme's own foreground color rather than any workbench.colorCustomizations
+      // override, which can leave the currently-selected icon a mismatched gray instead
+      // of Peacock's colorized foreground (#652). Set both explicitly so the active
+      // item's border always matches the rest of the icons.
+      activityBarSettings[ColorSettings.activityBar_activeBorder] = activityBarStyle.foregroundHex;
 
       activityBarSettings[ColorSettings.activityBarTop_foreground] = activityBarStyle.foregroundHex;
       activityBarSettings[ColorSettings.activityBarTop_inactiveForeground] =
         activityBarStyle.inactiveForegroundHex;
+      activityBarSettings[ColorSettings.activityBarTop_activeBorder] =
+        activityBarStyle.foregroundHex;
     }
 
     if (!keepBadgeColor) {

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -59,6 +59,7 @@ export enum ElementNames {
 
 export enum ColorSettings {
   activityBar_activeBackground = 'activityBar.activeBackground',
+  activityBar_activeBorder = 'activityBar.activeBorder',
   activityBar_background = 'activityBar.background',
   activityBar_foreground = 'activityBar.foreground',
   activityBar_inactiveForeground = 'activityBar.inactiveForeground',
@@ -67,6 +68,7 @@ export enum ColorSettings {
   // Activity Bar "on top" layout tokens (VS Code 1.84+)
   activityBarTop_background = 'activityBarTop.background',
   activityBarTop_activeBackground = 'activityBarTop.activeBackground',
+  activityBarTop_activeBorder = 'activityBarTop.activeBorder',
   activityBarTop_foreground = 'activityBarTop.foreground',
   activityBarTop_inactiveForeground = 'activityBarTop.inactiveForeground',
   commandCenter_border = 'commandCenter.border',

--- a/src/test/suite/activity-bar-top.test.ts
+++ b/src/test/suite/activity-bar-top.test.ts
@@ -5,6 +5,14 @@
  * When `workbench.activityBar.location` is set to "top", VS Code uses
  * `activityBarTop.*` color tokens instead of `activityBar.*`.
  * Peacock must set both token families so the highlight applies in either layout.
+ *
+ * Also covers #652 (modernUI compatibility): `activityBar.activeBorder` and
+ * `activityBarTop.activeBorder` both default, in VS Code itself, to the theme's
+ * own foreground color rather than any `workbench.colorCustomizations` override.
+ * Left unset, this can leave the currently-selected activity bar icon a
+ * mismatched gray instead of Peacock's colorized foreground under Modern UI.
+ * Peacock sets both explicitly so the active item's border always matches the
+ * rest of the icons.
  */
 import * as assert from 'assert';
 import { ColorSettings, Commands, peacockGreen } from '../../models';
@@ -113,6 +121,57 @@ suite('Activity Bar — "on top" layout (issue #538)', () => {
       );
     });
 
+    test('sets activityBar.activeBorder to match the computed foreground (#652)', async () => {
+      await updateKeepForegroundColor(false);
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      const activityBarStyle = getElementStyle(peacockGreen, 'activityBar');
+
+      assert.ok(
+        config[ColorSettings.activityBar_activeBorder],
+        'activityBar.activeBorder should be set',
+      );
+      assert.equal(
+        config[ColorSettings.activityBar_activeBorder],
+        activityBarStyle.foregroundHex,
+        'activityBar.activeBorder should match computed foreground so the active icon is not left VS Code\u2019s default gray',
+      );
+    });
+
+    test('sets activityBarTop.activeBorder to match the computed foreground (#652)', async () => {
+      await updateKeepForegroundColor(false);
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      const activityBarStyle = getElementStyle(peacockGreen, 'activityBar');
+
+      assert.ok(
+        config[ColorSettings.activityBarTop_activeBorder],
+        'activityBarTop.activeBorder should be set',
+      );
+      assert.equal(
+        config[ColorSettings.activityBarTop_activeBorder],
+        activityBarStyle.foregroundHex,
+        'activityBarTop.activeBorder should match computed foreground so the active icon is not left VS Code\u2019s default gray under Modern UI',
+      );
+    });
+
+    test('does not set activityBar.activeBorder or activityBarTop.activeBorder when keepForegroundColor is true', async () => {
+      await updateKeepForegroundColor(true);
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      assert.ok(
+        !config[ColorSettings.activityBar_activeBorder],
+        'activityBar.activeBorder should not be set when keepForegroundColor is true',
+      );
+      assert.ok(
+        !config[ColorSettings.activityBarTop_activeBorder],
+        'activityBarTop.activeBorder should not be set when keepForegroundColor is true',
+      );
+    });
+
     test('activityBarTop.background matches expected color value for peacock green', async () => {
       await executeCommand(Commands.changeColorToPeacockGreen);
       const config = getColorCustomizationConfig();
@@ -167,6 +226,20 @@ suite('Activity Bar — "on top" layout (issue #538)', () => {
       assert.ok(
         !config[ColorSettings.activityBarTop_inactiveForeground],
         'activityBarTop.inactiveForeground should not be set when activity bar is not affected',
+      );
+    });
+
+    test('does not set activityBar.activeBorder or activityBarTop.activeBorder when activity bar is not affected', async () => {
+      await executeCommand(Commands.changeColorToPeacockGreen);
+      const config = getColorCustomizationConfig();
+
+      assert.ok(
+        !config[ColorSettings.activityBar_activeBorder],
+        'activityBar.activeBorder should not be set when activity bar is not affected',
+      );
+      assert.ok(
+        !config[ColorSettings.activityBarTop_activeBorder],
+        'activityBarTop.activeBorder should not be set when activity bar is not affected',
       );
     });
 


### PR DESCRIPTION
## Summary

Fixes a real-world repro reported against #652: under VS Code's Modern UI (and, more subtly, the classic side layout too), the currently-selected activity bar icon can render VS Code's default gray instead of Peacock's colorized foreground, while every other (inactive) icon correctly picks up the Peacock color.

## Root cause

Confirmed directly against VS Code's own source (`src/vs/workbench/common/theme.ts`): both `activityBar.activeBorder` and `activityBarTop.activeBorder` are real, distinct color tokens whose *default* value is defined as a reference to the theme's own foreground color ID, not a resolution of any `workbench.colorCustomizations` override applied to that referenced ID. Peacock already sets `activityBar.foreground` / `activityBarTop.foreground` explicitly, but never set `activityBar.activeBorder` / `activityBarTop.activeBorder`, so the active icon's border could be left at a mismatched default instead of Peacock's colorized foreground.

## Fix

Set both tokens explicitly, matching the same computed foreground Peacock already uses for the rest of the activity bar icons, gated behind the existing `keepForegroundColor` check (consistent with how the other foreground-adjacent tokens are handled).

## Testing

- Added regression tests to `activity-bar-top.test.ts` covering both the classic (`activityBar.activeBorder`) and "on top" layout (`activityBarTop.activeBorder`) tokens, in both the affected/not-affected and `keepForegroundColor` true/false states.
- `npm run lint` — clean
- `npm run test:host` (full VS Code integration suite) — 196 passing, 1 pre-existing pending (unrelated `status-bar.test.ts` skip)
- `npm run test:unit` (Vitest) — 146 passing
- Updated `docs/changelog/README.md` under `## Unreleased`

## Related

- Adds evidence-backed fix for one of two symptoms reported against [#652](https://github.com/johnpapa/vscode-peacock/issues/652). Does not close the issue, since #652 also tracks a separate, not-yet-confirmed report about a sash-divider border color under Modern UI that needs a live VS Code repro before any fix lands there.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
