### PR TITLE
test(573): verify and lock in remoteColor persistence across reload/reconnect

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,12 @@
 
 All notable changes to the code will be documented in this file.
 
+## Unreleased
+
+### Tests
+
+- Added regression coverage confirming `peacock.remoteColor` is preserved (not overwritten with a new random color) across repeated `Developer: Reload Window`/reconnect cycles in a remote SSH/WSL/container workspace when `peacock.surpriseMeOnStartup` is enabled. Verified this exact scenario is already handled correctly by the startup-selection persistence added for [#582](https://github.com/johnpapa/vscode-peacock/issues/582) (released in 4.3.0) — no functional code change was required ([#573](https://github.com/johnpapa/vscode-peacock/issues/573))
+
 ## 4.4.1 (2026-09-07)
 
 ### Fixes

--- a/src/test/suite/surprise-me-on-startup.test.ts
+++ b/src/test/suite/surprise-me-on-startup.test.ts
@@ -19,12 +19,16 @@ import {
   updateSurpriseMeInFavoritesOrder,
   getEnvironmentAwareColor,
   updateSurpriseMeOnStartup,
+  updatePeacockColor,
+  updatePeacockRemoteColor,
+  getPeacockRemoteColor,
 } from '../../configuration';
 import { checkSurpriseMeOnStartupLogic } from '../../extension';
 import {
   resetFavoritesVersionMemento,
   saveSurpriseMeStartupSelectionGlobalMemento,
 } from '../../mementos';
+import { RemoteNames } from '../../remote';
 
 suite('Surprise me on startup', () => {
   const originalValues = {} as IPeacockSettings;
@@ -63,6 +67,41 @@ suite('Surprise me on startup', () => {
 
     teardown(async () => {
       await updateSurpriseMeOnStartup(false);
+    });
+  });
+
+  suite('when in a remote environment (#573)', () => {
+    setup(async () => {
+      await updateSurpriseMeOnStartup(true);
+    });
+
+    teardown(async () => {
+      await updateSurpriseMeOnStartup(false);
+    });
+
+    test('does not pick a new random color when peacock.remoteColor is already set on reload/reconnect', async () => {
+      const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.sshRemote);
+      try {
+        await updatePeacockColor('');
+        await updatePeacockRemoteColor('#f13768');
+
+        const randomStub = sinon.stub(Math, 'random');
+        try {
+          // Simulate reload/reconnect: run the startup logic repeatedly, as would
+          // happen on every "Developer: Reload Window" or SSH reconnect.
+          await checkSurpriseMeOnStartupLogic();
+          await checkSurpriseMeOnStartupLogic();
+          await checkSurpriseMeOnStartupLogic();
+
+          assert.equal(randomStub.callCount, 0);
+          assert.equal(getPeacockRemoteColor(), '#f13768');
+          assert.equal(getEnvironmentAwareColor(), '#f13768');
+        } finally {
+          randomStub.restore();
+        }
+      } finally {
+        remoteNameStub.restore();
+      }
     });
   });
 


### PR DESCRIPTION
> 🤖 This PR was generated by GitHub Copilot using the **AI-Ready** skill.

## Summary

Investigates and resolves #573 (`peacock.remoteColor` reportedly overwritten with a new random color on every "Developer: Reload Window" or SSH reconnect when `peacock.surpriseMeOnStartup` is enabled).

**Finding**: the exact repro from the issue is already handled correctly by the current codebase. `checkSurpriseMeOnStartupLogic()` (in `src/extension.ts`) short-circuits whenever `getEnvironmentAwareColor()` — which is remote-aware and checks `peacock.remoteColor` when `vscode.env.remoteName` is set — returns an already-configured color, and never proceeds to pick a new random one. This protection was added by the startup-selection persistence work for #582, which shipped in **4.3.0** — a version released after 4.2.2, the version the reporter had installed when filing #573.

No functional code change was required.

## What changed

- Added a host-lane regression test (`src/test/suite/surprise-me-on-startup.test.ts`) that stubs `vscode.env.remoteName` to simulate a remote SSH/WSL/container session, sets `peacock.remoteColor`, enables `peacock.surpriseMeOnStartup`, and runs `checkSurpriseMeOnStartupLogic()` multiple times in a row (simulating repeated reloads/reconnects). Asserts the color is never re-randomized and `peacock.remoteColor` stays untouched.
- Added a changelog entry under a fresh `## Unreleased` heading.

## How to test

```bash
npm run just-test
```

The new test lives under "Surprise me on startup" → "when in a remote environment (#573)".

## Checklist

- [x] Regression test added and passing locally
- [x] `npx tsc --noEmit -p .` clean
- [x] `npm run lint` clean
- [x] Changelog updated
- [x] No functional/behavioral code change (verification-only fix)

Closes #573