### PR TITLE
Prefix the status bar with a remote indicator

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -6,6 +6,7 @@ All notable changes to the code will be documented in this file.
 
 ### Tests
 
+- Added host-lane regression coverage for the remote status bar indicator (`$(remote)` prefix + updated tooltip when `vscode.env.remoteName` is set), stubbing the remote context the same way `remote.test.ts` already does ([#392](https://github.com/johnpapa/vscode-peacock/issues/392))
 - Added regression coverage confirming `peacock.remoteColor` is preserved (not overwritten with a new random color) across repeated `Developer: Reload Window`/reconnect cycles in a remote SSH/WSL/container workspace when `peacock.surpriseMeOnStartup` is enabled. Verified this exact scenario is already handled correctly by the startup-selection persistence added for [#582](https://github.com/johnpapa/vscode-peacock/issues/582) (released in 4.3.0) — no functional code change was required ([#573](https://github.com/johnpapa/vscode-peacock/issues/573))
 
 ## 4.4.1 (2026-09-07)

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -4,6 +4,10 @@ All notable changes to the code will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+- Peacock's status bar item now signals a remote window. When `vscode.env.remoteName` is set (Remote SSH, WSL, Dev Containers, and similar), the item reads `$(remote) $(paintcan) <color>` instead of `$(paintcan) <color>`, and its tooltip includes the remote name. The existing `statusBarItem.remoteBackground`/`remoteForeground` coloring is unchanged; this only adds a readable text cue for the case where the color alone is easy to miss at a glance ([#392](https://github.com/johnpapa/vscode-peacock/issues/392))
+
 ### Tests
 
 - Added host-lane regression coverage for the remote status bar indicator (`$(remote)` prefix + updated tooltip when `vscode.env.remoteName` is set), stubbing the remote context the same way `remote.test.ts` already does ([#392](https://github.com/johnpapa/vscode-peacock/issues/392))

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -317,6 +317,8 @@ Peacock detects when the [VS Code Remote](https://marketplace.visualstudio.com/i
 
 When a workspace is opened in a remote context, if a `peacock.remoteColor` is set, it will be applied. Otherwise, the regular `peacock.color` is applied.
 
+When `peacock.showColorInStatusBar` is enabled, the Peacock status bar item in a remote window also shows a remote icon before the paint can, and its tooltip names the remote (for example `ssh-remote` or `wsl`), so you can tell a remote window from a local one at a glance even when both use similar colors.
+
 ![Remote Integration with Peacock](../assets/peacock-remote.gif)
 
 VS Code distinguishes two classes of extensions: UI Extensions and Workspace Extensions. Peacock is classified as a UI extension as it makes contributions to the VS Code user interface and is always run on the user's local machine. UI Extensions cannot directly access files in the workspace, or run scripts/tools installed in that workspace or on the machine. Example UI Extensions include: themes, snippets, language grammars, and keymaps.

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -1,4 +1,4 @@
-import { StatusBarAlignment, window, StatusBarItem } from 'vscode';
+import { StatusBarAlignment, window, StatusBarItem, env } from 'vscode';
 import { getShowColorInStatusBar, getEnvironmentAwareColor } from './configuration';
 import { Commands } from './models';
 
@@ -19,9 +19,17 @@ export function updateStatusBar() {
   const sb = _statusBarItem;
   const show = getShowColorInStatusBar();
   const color = getEnvironmentAwareColor();
-  sb.text = `$(paintcan) ${color}`;
+  // Peacock already colors statusBarItem.remoteBackground/remoteForeground
+  // differently in a remote context, but that alone is easy to miss at a
+  // glance (#392) -- the paintcan icon looks the same either way. A $(remote)
+  // prefix makes "this window is remote" readable from the status bar text
+  // itself, with no new color tokens or theme keys involved.
+  const remotePrefix = env.remoteName ? '$(remote) ' : '';
+  sb.text = `${remotePrefix}$(paintcan) ${color}`;
   sb.command = Commands.showAndCopyCurrentColor;
-  sb.tooltip = 'Copy the Peacock color';
+  sb.tooltip = env.remoteName
+    ? `Copy the Peacock color (remote: ${env.remoteName})`
+    : 'Copy the Peacock color';
   if (show && !!color) {
     sb.show();
   } else {

--- a/src/test/suite/status-bar-remote-indicator.test.ts
+++ b/src/test/suite/status-bar-remote-indicator.test.ts
@@ -1,0 +1,50 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { IPeacockSettings, peacockGreen } from '../../models';
+import { setupTestSuite, teardownTestSuite, setupTest } from './lib/setup-teardown-test-suite';
+import { executeCommand } from './lib/constants';
+import { Commands } from '../../models';
+import { RemoteNames } from '../../remote';
+import { getStatusBarItem } from '../../statusbar';
+import { updatePeacockRemoteColor } from '../../configuration';
+
+suite('StatusBar remote indicator (#392)', () => {
+  const originalValues = {} as IPeacockSettings;
+
+  suiteSetup(async () => await setupTestSuite(originalValues));
+  suiteTeardown(async () => await teardownTestSuite(originalValues));
+  setup(async () => await setupTest());
+
+  setup(async () => {
+    await executeCommand(Commands.changeColorToPeacockGreen);
+  });
+
+  test('does not prefix the status bar text when not in a remote context', async () => {
+    const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(undefined);
+    try {
+      const sb = getStatusBarItem();
+      assert.ok(!sb.text.startsWith('$(remote)'));
+      assert.ok(sb.text.includes(peacockGreen));
+      assert.equal(sb.tooltip, 'Copy the Peacock color');
+    } finally {
+      remoteNameStub.restore();
+    }
+  });
+
+  test('prefixes the status bar text with a remote indicator when in a remote context', async () => {
+    const remoteNameStub = sinon.stub(vscode.env, 'remoteName').value(RemoteNames.sshRemote);
+    try {
+      // getEnvironmentAwareColor() reads peacock.remoteColor (not peacock.color)
+      // once a remote context is active, so it must be set explicitly here.
+      await updatePeacockRemoteColor(peacockGreen);
+
+      const sb = getStatusBarItem();
+      assert.ok(sb.text.startsWith('$(remote) $(paintcan)'));
+      assert.ok(sb.text.includes(peacockGreen));
+      assert.equal(sb.tooltip, `Copy the Peacock color (remote: ${RemoteNames.sshRemote})`);
+    } finally {
+      remoteNameStub.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Purpose

- Addresses the core ask in #392: a stronger, harder-to-miss visual signal that a window is remote, beyond the existing `statusBarItem.remoteBackground`/`remoteForeground` color tokens (which use the same icon/text either way, so they're easy to miss at a glance).

## What

- When `vscode.env.remoteName` is set, Peacock's own status bar item now shows `$(remote) $(paintcan) <color>` instead of just `$(paintcan) <color>`, and the tooltip includes the remote name.
- No new color tokens, no theming API — just text/tooltip on the status bar item Peacock already owns.
- This is a smaller, safer slice of what #392 asked for (the "hatching" idea in the original request isn't feasible via `workbench.colorCustomizations` — no such visual effect exists in the theming API). Left a comment on the issue explaining that tradeoff and this alternative.

## How to Test

- `npx tsc -p ./ --noEmit`, `npm run lint`, `npm run test:unit` all pass locally.
- Host-lane regression test `src/test/suite/status-bar-remote-indicator.test.ts` stubs `vscode.env.remoteName` with sinon, the same pattern `remote.test.ts` already uses, and checks both the non-remote (no prefix, plain tooltip) and remote (`$(remote) $(paintcan)` prefix, tooltip with remote name) cases. An earlier revision of this description claimed no test lane could cover this; that was wrong — only the Vitest mock lacks `env.remoteName`, and the host lane is the right lane for `vscode` API code anyway.
- Manual check: open a Remote-SSH/WSL/Container window and confirm the status bar reads `$(remote) $(paintcan) #hexcolor`.

## Checklist of changes included

- [x] CHANGELOG updated — Features entry (and the Tests entry for the regression test) under `## Unreleased` in `docs/changelog/README.md`, per AGENTS.md
- [x] README updated — `docs/guide/README.md` Remote Development Integration section now describes the remote icon and tooltip on the status bar item
- [x] Tests updated/added
- [x] Prettier formatting
- [x] console.log removed (none added)
- [x] Dead code removed
- [x] Unnecessary comments removed
- [ ] Images updated — n/a
- [ ] Version updated everywhere — release-time decision

**Not merging this** — opening for your review as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8XirhXqSmMN7qBP6hmVG1)_