### PR TITLE
docs: add convention for verifying "can't be tested" claims

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ VS Code extension written in TypeScript, bundled with Webpack, published to the 
 - Tests use `testworkspace/` as the VS Code workspace
 - **Every bug fix must include a regression test** that fails without the fix and passes with it
 - **Every new feature must include unit tests** covering the happy path and relevant edge cases
+- **Don't accept "this can't be tested" claims at face value.** Grep `src/test/` for the exact `vscode` API/state the change depends on — if any existing suite already stubs it (host lane can `sinon.stub(vscode.env, ...)`), reuse that lane/pattern instead of skipping the test. See PR #757 for a worked example.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ npm run package:check           # Package the VSIX and verify contents/size (see
 - Every new feature must include unit tests covering the happy path and relevant edge cases
 - Never merge code that reduces the passing test count
 - UI/theme-affecting changes (status bar, title bar, activity bar, color tokens) should be verified on Windows, VS Live Share, and Cursor before considering the fix complete — automated tests alone haven't caught real-world issues here in the past
+- **Treat "this can't be tested" claims in a PR as a hypothesis to verify, not a fact to accept.** Before agreeing, `grep` `src/test/` for the exact `vscode` API/state the new code depends on (e.g. `env.remoteName`, a config key, a command). If any existing suite already stubs/mocks that exact dependency (host lane can `sinon.stub(vscode.env, ...)`; unit lane only has what's in `src/test/unit/mocks/vscode.ts`), the claim usually means "untestable in the one lane I checked," not "untestable everywhere" — write the test in the lane that already supports it instead of skipping coverage. See PR #757 for a worked example (claim was wrong; host-lane precedent existed in `remote.test.ts`).
 
 ## Key Patterns and Conventions
 


### PR DESCRIPTION
## Summary

Adds a durable AI-context convention (to both `AGENTS.md` and `.github/copilot-instructions.md`) documenting how to verify a PR's "no automated test can cover this" claim before accepting it, based on the investigation done for PR #757.

## What changed

- `AGENTS.md` → **Test requirements**: new bullet instructing agents to `grep` `src/test/` for the exact `vscode` API/state a change depends on before agreeing a feature is untestable, and to check for existing stubbing precedent (e.g. host lane `sinon.stub(vscode.env, ...)`) before skipping coverage.
- `.github/copilot-instructions.md` → **Test Conventions**: same convention, condensed for the Copilot-instructions format.

## Why

PR #757 claimed no test lane could cover a new remote-status-bar-indicator feature because the Vitest mock lacks `env.remoteName`. That's true for the unit lane, but `src/test/suite/remote.test.ts` already stubs `vscode.env.remoteName` via sinon in the host lane — the claim didn't hold once the other lane was checked. A regression test was added to PR #757 to prove it. This PR captures that methodology as a repo convention so future PRs (and AI agents) check both lanes before declaring something untestable.

## How to test

Docs-only change — no code affected. `npm run lint` / `npm test` unaffected.
